### PR TITLE
Remove dependency on app.json

### DIFF
--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -15,6 +15,7 @@ describe("index", () => {
     tmpDir = tmp.dirSync({
       unsafeCleanup: true
     });
+    process.chdir(tmpDir.name);
   });
   afterEach(() => {
     tmpDir.removeCallback();
@@ -31,6 +32,23 @@ describe("index", () => {
     () => testFixture("text", 0.06),
     20 * 1000
   );
+
+  it("determines the correct ios asset path", async () => {
+    fse.ensureDir(path.join("ios", "project", "Images.xcassets"));
+
+    const generator = index.generate({
+      icon: path.join(fixturesPath, "example", "icon.svg")
+    });
+
+    const generatedFiles = [];
+    for await (let file of generator) {
+      generatedFiles.push(file);
+    }
+
+    expect(generatedFiles).toContain(
+      "ios/project/Images.xcassets/AppIcon.appiconset/iphone-40@3x.png"
+    );
+  });
 
   async function testFixture(
     fixture: string,

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -47,7 +47,13 @@ describe("index", () => {
         "main",
         "res"
       ),
-      iconsetDir: path.join(tmpDir.name, "ios", fixture, "Images.xcassets")
+      iconsetDir: path.join(
+        tmpDir.name,
+        "ios",
+        fixture,
+        "Images.xcassets",
+        "AppIcon.appiconset"
+      )
     });
 
     const generatedFiles = [];


### PR DESCRIPTION
Removes the inferring of iOS project name through `app.json`. Instead works similarly to [app-icon](https://github.com/dwmkerr/app-icon/blob/v0.13.0/src/ios/find-iconset-folders.js) and [react-native-cli](https://github.com/react-native-community/cli/blob/v2.7.0/packages/platform-ios/src/commands/runIOS/findXcodeProject.js) heuristics.

Fixes #13 