### PR TITLE
Add 'platforms' configuration field

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ Behaviour can be configured in the `app.json` under the `svgAppIcon` field. For 
   "svgAppIcon": {
     "foregroundPath": "./icon/icon-foreground.svg",
     "backgroundPath": "./icon/icon-background.svg",
-    "excludePlatforms": ["android"]
+    "platforms": ["ios"]
   }
 }
 ```
 
 Supported configuration values are
 
-| Field              | Default                   | Description                                                                                                                                                     |
-| ------------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `foregroundPath`   | `"./icon.svg"`            | Input file path for the foreground layer. File needs to exist, and may contain transparency.                                                                    |
-| `backgroundPath`   | `"./icon-background.svg"` | Input file path for the background layer. File doesn't need to exist, and will default to a fully white background. If file exist, it needs to be fully opaque. |
-| `excludePlatforms` | `[]`                      | Array of platforms for which no application launcher icons should be generated. Possible values are `android` and `ios`.                                        |
+| Field            | Default                   | Description                                                                                                                                                     |
+| ---------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `foregroundPath` | `"./icon.svg"`            | Input file path for the foreground layer. File needs to exist, and may contain transparency.                                                                    |
+| `backgroundPath` | `"./icon-background.svg"` | Input file path for the background layer. File doesn't need to exist, and will default to a fully white background. If file exist, it needs to be fully opaque. |
+| `platforms`      | `["android", "ios"]`      | Array of platforms for which application launcher icons should be generated. Possible values are `android` and `ios`.                                           |
 
 ## Icon format
 

--- a/README.md
+++ b/README.md
@@ -64,17 +64,19 @@ Behaviour can be configured in the `app.json` under the `svgAppIcon` field. For 
   "displayName": "example",
   "svgAppIcon": {
     "foregroundPath": "./icon/icon-foreground.svg",
-    "backgroundPath": "./icon/icon-background.svg"
+    "backgroundPath": "./icon/icon-background.svg",
+    "excludePlatforms": ["android"]
   }
 }
 ```
 
 Supported configuration values are
 
-| Field            | Default                   | Description                                                                                                                                                     |
-| ---------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `foregroundPath` | `"./icon.svg"`            | Input file path for the foreground layer. File needs to exist, and may contain transparency.                                                                    |
-| `backgroundPath` | `"./icon-background.svg"` | Input file path for the background layer. File doesn't need to exist, and will default to a fully white background. If file exist, it needs to be fully opaque. |
+| Field              | Default                   | Description                                                                                                                                                     |
+| ------------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `foregroundPath`   | `"./icon.svg"`            | Input file path for the foreground layer. File needs to exist, and may contain transparency.                                                                    |
+| `backgroundPath`   | `"./icon-background.svg"` | Input file path for the background layer. File doesn't need to exist, and will default to a fully white background. If file exist, it needs to be fully opaque. |
+| `excludePlatforms` | `[]`                      | Array of platforms for which no application launcher icons should be generated. Possible values are `android` and `ios`.                                        |
 
 ## Icon format
 

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -44,7 +44,8 @@ describe("index", () => {
           "icon-background.svg"
         ),
         foregroundPath: path.join(fixturesPath, "example", "icon.svg")
-      }
+      },
+      platforms: ["android", "ios"]
     });
 
     const generatedFiles = [];
@@ -71,6 +72,7 @@ describe("index", () => {
           : undefined,
         foregroundPath: path.join(fixtureDir, "icon.svg")
       },
+      platforms: ["android", "ios"],
       resDirPath: path.join(
         tmpDir.name,
         "android",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,13 @@ import * as reactNativeSvgAppIcon from "./index";
 type CliConfig = {
   backgroundPath: string;
   foregroundPath: string;
+  excludePlatforms: Platform[];
 };
+
+/**
+ * Supported platforms for generating icons.
+ */
+type Platform = "android" | "ios";
 
 /**
  * Custom extension of RN / Expo app.json for file based configuration.
@@ -27,7 +33,8 @@ type AppJson = Partial<{
  */
 const defaultCliConfig: CliConfig = {
   backgroundPath: "./icon-background.svg",
-  foregroundPath: "./icon.svg"
+  foregroundPath: "./icon.svg",
+  excludePlatforms: []
 };
 
 async function main(): Promise<void> {
@@ -50,6 +57,10 @@ async function main(): Promise<void> {
         ? cliConfig.backgroundPath
         : undefined,
       foregroundPath: cliConfig.foregroundPath
+    },
+    exclude: {
+      android: cliConfig.excludePlatforms.includes("android"),
+      ios: cliConfig.excludePlatforms.includes("ios")
     }
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,9 +43,14 @@ async function main(): Promise<void> {
   let cliConfig: CliConfig;
   try {
     const appJson = (await fse.readJson("./app.json")) as AppJson;
+    const { platforms, ...appJsonConfig } = appJson.svgAppIcon || {};
+
     cliConfig = {
       ...defaultCliConfig,
-      ...appJson.svgAppIcon
+      ...appJsonConfig,
+      ...(Array.isArray(platforms) && {
+        platforms: platforms.map((e) => e.toLowerCase() as Platform)
+      })
     };
   } catch {
     cliConfig = defaultCliConfig;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,13 +11,13 @@ import * as reactNativeSvgAppIcon from "./index";
 type CliConfig = {
   backgroundPath: string;
   foregroundPath: string;
-  excludePlatforms: Platform[];
+  platforms: Platform[];
 };
 
 /**
  * Supported platforms for generating icons.
  */
-type Platform = "android" | "ios";
+export type Platform = "android" | "ios";
 
 /**
  * Custom extension of RN / Expo app.json for file based configuration.
@@ -34,7 +34,7 @@ type AppJson = Partial<{
 const defaultCliConfig: CliConfig = {
   backgroundPath: "./icon-background.svg",
   foregroundPath: "./icon.svg",
-  excludePlatforms: []
+  platforms: ["android", "ios"]
 };
 
 async function main(): Promise<void> {
@@ -58,10 +58,7 @@ async function main(): Promise<void> {
         : undefined,
       foregroundPath: cliConfig.foregroundPath
     },
-    exclude: {
-      android: cliConfig.excludePlatforms.includes("android"),
-      ios: cliConfig.excludePlatforms.includes("ios")
-    }
+    platforms: cliConfig.platforms
   });
 
   for await (const file of generatedFiles) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,20 @@ import * as input from "./input";
 import * as android from "./android";
 import * as ios from "./ios";
 
+import { Platform } from "./cli";
+
 export interface Config extends Partial<android.Config>, Partial<ios.Config> {
   icon: Partial<input.Config>;
-  exclude?: { android: boolean; ios: boolean };
+  platforms: Platform[];
 }
 
 export async function* generate(config: Config): AsyncIterable<string> {
   const iconInput = await input.readIcon(config.icon);
 
-  if (!config.exclude?.android) yield* android.generate(config, iconInput);
-  if (!config.exclude?.ios) yield* ios.generate(config, iconInput);
+  if (config.platforms.includes("android")) {
+    yield* android.generate(config, iconInput);
+  }
+  if (config.platforms.includes("ios")) {
+    yield* ios.generate(config, iconInput);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,12 @@ import * as ios from "./ios";
 
 export interface Config extends Partial<android.Config>, Partial<ios.Config> {
   icon: Partial<input.Config>;
+  exclude?: { android: boolean; ios: boolean };
 }
 
 export async function* generate(config: Config): AsyncIterable<string> {
   const iconInput = await input.readIcon(config.icon);
 
-  yield* android.generate(config, iconInput);
-  yield* ios.generate(config, iconInput);
+  if (!config.exclude?.android) yield* android.generate(config, iconInput);
+  if (!config.exclude?.ios) yield* ios.generate(config, iconInput);
 }


### PR DESCRIPTION
## Description
Implements #53 

This pull request adds support for a new configuration field `platforms`, which allows users to specify an array of platforms (`android` or `ios`), for which application launcher icons should be generated (see linked issue for motivation).

```ts
// index.ts
export interface Config extends Partial<android.Config>, Partial<ios.Config> {
  icon: Partial<input.Config>;
  platforms: Platform[];
}

export async function* generate(config: Config): AsyncIterable<string> {
  // [..]
  if (config.platforms.includes("android")) {
    yield* android.generate(config, iconInput);
  }
  if (config.platforms.includes("ios")) {
    yield* ios.generate(config, iconInput);
  }
}
```
To achieve this I added a new parameter to the internal `Config`, modified `generate()` so the platform specific methods are only called when included in the parameter and propagated these changes to `cli.ts`.

I also updated the `README.md` to provide documentation for the added configuration field.

## Test plan
Unfortunately I had issues getting the existing test to run properly in my Windows environment (even before making any changes) and therefore wasn't able to add any new ones for this feature either. 

However I did manually try all possible configurations for the field and it always behaved like intended.
