### PR TITLE
Add option to force writing output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Behaviour can be configured in the `app.json` under the `svgAppIcon` field. For 
   "svgAppIcon": {
     "foregroundPath": "./icon/icon-foreground.svg",
     "backgroundPath": "./icon/icon-background.svg",
-    "platforms": ["ios"]
+    "platforms": ["ios"],
+    "force": false
   }
 }
 ```
@@ -77,6 +78,7 @@ Supported configuration values are
 | `foregroundPath` | `"./icon.svg"`            | Input file path for the foreground layer. File needs to exist, and may contain transparency.                                                                    |
 | `backgroundPath` | `"./icon-background.svg"` | Input file path for the background layer. File doesn't need to exist, and will default to a fully white background. If file exist, it needs to be fully opaque. |
 | `platforms`      | `["android", "ios"]`      | Array of platforms for which application launcher icons should be generated. Possible values are `android` and `ios`.                                           |
+| `force`          | `false`                   | When `true`, output files will always be written even if they are newer than the input files.                                                                   |
 
 ## Icon format
 

--- a/src/android.ts
+++ b/src/android.ts
@@ -139,7 +139,7 @@ function getViewBox(input: number): string {
   return viewBox.join(" ");
 }
 
-export interface Config {
+export interface Config extends output.OutputConfig {
   resDirPath: string;
   vectorDrawables: boolean;
 }
@@ -158,7 +158,8 @@ function getConfig(config: Partial<Config>): Config {
   return {
     resDirPath: config.resDirPath || "./android/app/src/main/res",
     vectorDrawables:
-      config.vectorDrawables === undefined ? true : config.vectorDrawables
+      config.vectorDrawables === undefined ? true : config.vectorDrawables,
+    force: config.force || false
   };
 }
 
@@ -185,7 +186,8 @@ async function* generateLegacyIcons(
         { density: density.name },
         `${launcherName}.png`
       ),
-      outputSize: legacyIconBaseSize * density.scale
+      outputSize: legacyIconBaseSize * density.scale,
+      force: config.force
     }))
   );
 }
@@ -213,7 +215,8 @@ async function* generateRoundIcons(
         { density: density.name },
         `${roundIconName}.png`
       ),
-      outputSize: legacyIconBaseSize * density.scale
+      outputSize: legacyIconBaseSize * density.scale,
+      force: config.force
     }))
   );
 }
@@ -274,7 +277,8 @@ async function* generateAdaptiveIcon(
       { density: "anydpi", minApiLevel: 26 },
       `${launcherName}.xml`
     ),
-    adaptiveIconXml
+    adaptiveIconXml,
+    config
   );
   yield* output.ensureFileContents(
     getIconPath(
@@ -283,7 +287,8 @@ async function* generateAdaptiveIcon(
       { density: "anydpi", minApiLevel: 26 },
       `${roundIconName}.xml`
     ),
-    adaptiveIconXml
+    adaptiveIconXml,
+    config
   );
 }
 
@@ -309,7 +314,8 @@ async function* generateAdaptiveIconLayerVd(
       { density: "anydpi", minApiLevel: 26 },
       `${fileName}.xml`
     ),
-    vdData
+    vdData,
+    config
   );
 }
 
@@ -329,7 +335,8 @@ async function* generateAdaptiveIconLayerPng(
         { density: density.name, minApiLevel: adaptiveIconMinSdk },
         `${fileName}.png`
       ),
-      outputSize: adaptiveIconBaseSize * density.scale
+      outputSize: adaptiveIconBaseSize * density.scale,
+      force: config.force
     }))
   );
 }

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -25,7 +25,7 @@ const iosIcons = [
   { idiom: "ios-marketing", scale: 1, size: 1024, flattenAlpha: true }
 ];
 
-export interface Config {
+export interface Config extends output.OutputConfig {
   iconsetDir: string;
 }
 export async function* generate(
@@ -40,7 +40,8 @@ export async function* generate(
 
 async function getConfig(config: Partial<Config>): Promise<Config> {
   return {
-    iconsetDir: config.iconsetDir || (await getIconsetDir())
+    iconsetDir: config.iconsetDir || (await getIconsetDir()),
+    force: config.force || false
   };
 }
 
@@ -76,25 +77,30 @@ async function* generateImages(
     iosIcons.map((icon) => ({
       filePath: path.join(config.iconsetDir, getIconFilename(icon)),
       flattenAlpha: icon.flattenAlpha,
-      outputSize: icon.size * icon.scale
+      outputSize: icon.size * icon.scale,
+      force: config.force
     }))
   );
 }
 
 async function* generateManifest(config: Config): AsyncIterable<string> {
   const fileName = path.join(config.iconsetDir, "Contents.json");
-  yield* output.ensureFileContents(fileName, {
-    images: iosIcons.map((icon) => ({
-      filename: getIconFilename(icon),
-      idiom: icon.idiom,
-      scale: `${icon.scale}x`,
-      size: `${icon.size}x${icon.size}`
-    })),
-    info: {
-      author: "react-native-svg-app-icon",
-      version: 1
-    }
-  });
+  yield* output.ensureFileContents(
+    fileName,
+    {
+      images: iosIcons.map((icon) => ({
+        filename: getIconFilename(icon),
+        idiom: icon.idiom,
+        scale: `${icon.scale}x`,
+        size: `${icon.size}x${icon.size}`
+      })),
+      info: {
+        author: "react-native-svg-app-icon",
+        version: 1
+      }
+    },
+    config
+  );
 }
 
 function getIconFilename(icon: {


### PR DESCRIPTION
Adds configuration option to force writing output files, even though they would exist and already be newer than the input files. This is useful in scenarios where the input files are changed based on for example build environment.

Additionally exposes all configuration options as command line arguments. This also makes it easier to switch icons more easily.

Fixes #63 