### PR TITLE
feat(output-paths): expose androidOutputPath / iosOutputPath configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,23 @@ Behaviour can be configured in the `app.json` under the `svgAppIcon` field. For 
     "foregroundPath": "./icon/icon-foreground.svg",
     "backgroundPath": "./icon/icon-background.svg",
     "platforms": ["ios"],
-    "force": false
+    "force": false,
+    "androidOutputPath": "./android/app/src/main/res",
+    "iosOutputPath": "./ios/MyAppName/Images.xcassets/AppIcon.appiconset"
   }
 }
 ```
 
 Supported configuration values are
 
-| Field            | Default                   | Description                                                                                                                                                     |
-| ---------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `foregroundPath` | `"./icon.svg"`            | Input file path for the foreground layer. File needs to exist, and may contain transparency.                                                                    |
-| `backgroundPath` | `"./icon-background.svg"` | Input file path for the background layer. File doesn't need to exist, and will default to a fully white background. If file exist, it needs to be fully opaque. |
-| `platforms`      | `["android", "ios"]`      | Array of platforms for which application launcher icons should be generated. Possible values are `android` and `ios`.                                           |
-| `force`          | `false`                   | When `true`, output files will always be written even if they are newer than the input files.                                                                   |
+| Field               | Default                                              | Description                                                                                                                                                     |
+| ------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `foregroundPath`    | `"./icon.svg"`                                       | Input file path for the foreground layer. File needs to exist, and may contain transparency.                                                                    |
+| `backgroundPath`    | `"./icon-background.svg"`                            | Input file path for the background layer. File doesn't need to exist, and will default to a fully white background. If file exist, it needs to be fully opaque. |
+| `platforms`         | `["android", "ios"]`                                 | Array of platforms for which application launcher icons should be generated. Possible values are `android` and `ios`.                                           |
+| `force`             | `false`                                              | When `true`, output files will always be written even if they are newer than the input files.                                                                   |
+| `androidOutputPath` | `./android/app/src/main/res`                         | Where to place generated Android icons                                                                                                                          |
+| `iosOutputPath`     | `./ios/*/Images.xcassets/AppIcon.appiconset`         | Where to place generated iOS icons, defaults to first `Images.xcassets` found as a sub-sub-directory in `./ios`                                                 |
 
 Alternatively, the configuration parameters can also be set as CLI flags. See `react-native-svg-app-icon --help` for details.
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Supported configuration values are
 | `backgroundPath`    | `"./icon-background.svg"`                            | Input file path for the background layer. File doesn't need to exist, and will default to a fully white background. If file exist, it needs to be fully opaque. |
 | `platforms`         | `["android", "ios"]`                                 | Array of platforms for which application launcher icons should be generated. Possible values are `android` and `ios`.                                           |
 | `force`             | `false`                                              | When `true`, output files will always be written even if they are newer than the input files.                                                                   |
-| `androidOutputPath` | `./android/app/src/main/res`                         | Where to place generated Android icons                                                                                                                          |
-| `iosOutputPath`     | `./ios/*/Images.xcassets/AppIcon.appiconset`         | Where to place generated iOS icons, defaults to first `Images.xcassets` found as a sub-sub-directory in `./ios`                                                 |
+| `androidOutputPath` | `./android/app/src/main/res`                         | Where to place generated Android icons, can be used for flavor-specific icon generation                                                                         |
+| `iosOutputPath`     | `./ios/*/Images.xcassets/AppIcon.appiconset`         | Where to place generated iOS icons, defaults to `AppIcon.appiconset` in first `Images.xcassets` found as a sub-sub-directory in `./ios`                         |
 
 Alternatively, the configuration parameters can also be set as CLI flags. See `react-native-svg-app-icon --help` for details.
 

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -89,7 +89,7 @@ describe("index", () => {
           : undefined,
         foregroundPath: path.join(fixtureDir, "icon.svg")
       },
-      resDirPath: path.join(
+      androidOutputPath: path.join(
         tmpDir.name,
         "android",
         "app",
@@ -97,7 +97,7 @@ describe("index", () => {
         "main",
         "res"
       ),
-      iconsetDir: path.join(
+      iosOutputPath: path.join(
         tmpDir.name,
         "ios",
         fixture,

--- a/src/android.ts
+++ b/src/android.ts
@@ -140,7 +140,7 @@ function getViewBox(input: number): string {
 }
 
 export interface Config extends output.OutputConfig {
-  resDirPath: string;
+  androidOutputPath: string;
   vectorDrawables: boolean;
 }
 
@@ -156,7 +156,7 @@ export async function* generate(
 
 function getConfig(config: Partial<Config>): Config {
   return {
-    resDirPath: config.resDirPath || "./android/app/src/main/res",
+    androidOutputPath: config.androidOutputPath || "./android/app/src/main/res",
     vectorDrawables:
       config.vectorDrawables === undefined ? true : config.vectorDrawables,
     force: config.force || false
@@ -370,5 +370,5 @@ function getIconPath(
   if (qualifier.minApiLevel) {
     directoryName = [...directoryName, `v${qualifier.minApiLevel}`];
   }
-  return path.join(config.resDirPath, directoryName.join("-"), fileName);
+  return path.join(config.androidOutputPath, directoryName.join("-"), fileName);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,10 +65,8 @@ async function main(args: string[] = []): Promise<void> {
     },
     platforms: cliConfig.platforms,
     force: cliConfig.force,
-    androidOutputPath: (await fse.pathExists(cliConfig.androidOutputPath))
-      ? cliConfig.androidOutputPath
-      : undefined,
-    iosOutputPath: cliConfig.iosOutputPath ?? undefined // no default, determined dynamically in ios.ts
+    androidOutputPath: cliConfig.androidOutputPath,
+    iosOutputPath: cliConfig.iosOutputPath
   });
 
   for await (const file of generatedFiles) {
@@ -82,7 +80,6 @@ async function readFileConfig(): Promise<Partial<CliConfig>> {
     const appJson = (await fse.readJson("./app.json")) as AppJson;
     return appJson.svgAppIcon || {};
   } catch (error) {
-    console.log(`Configuration error: ${JSON.stringify(error)}`);
     return {};
   }
 }
@@ -123,13 +120,13 @@ async function readArgsConfig(args: string[]): Promise<Partial<CliConfig>> {
       // --android-output-path
       .opt()
       .name("androidOutputPath")
-      .title("android output path")
+      .title("Android Output Path")
       .long("android-output-path")
       .end()
       // --ios-output-path
       .opt()
       .name("iosOutputPath")
-      .title("ios-output path")
+      .title("iOS Output Path")
       .long("ios-output-path")
       .end()
       .act(resolve)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,8 @@ type CliConfig = {
   foregroundPath: string;
   platforms: Platform[];
   force: boolean;
+  androidOutputPath: string;
+  iosOutputPath?: string;
 };
 
 /**
@@ -37,7 +39,8 @@ const defaultConfig: CliConfig = {
   backgroundPath: "./icon-background.svg",
   foregroundPath: "./icon.svg",
   platforms: ["android", "ios"],
-  force: false
+  force: false,
+  androidOutputPath: "./android/app/src/main/res"
 };
 
 async function main(args: string[] = []): Promise<void> {
@@ -61,7 +64,11 @@ async function main(args: string[] = []): Promise<void> {
       foregroundPath: cliConfig.foregroundPath
     },
     platforms: cliConfig.platforms,
-    force: cliConfig.force
+    force: cliConfig.force,
+    androidOutputPath: (await fse.pathExists(cliConfig.androidOutputPath))
+      ? cliConfig.androidOutputPath
+      : undefined,
+    iosOutputPath: cliConfig.iosOutputPath ?? undefined // no default, determined dynamically in ios.ts
   });
 
   for await (const file of generatedFiles) {
@@ -75,6 +82,7 @@ async function readFileConfig(): Promise<Partial<CliConfig>> {
     const appJson = (await fse.readJson("./app.json")) as AppJson;
     return appJson.svgAppIcon || {};
   } catch (error) {
+    console.log(`Configuration error: ${JSON.stringify(error)}`);
     return {};
   }
 }
@@ -111,6 +119,18 @@ async function readArgsConfig(args: string[]): Promise<Partial<CliConfig>> {
       .long("force")
       .short("f")
       .flag()
+      .end()
+      // --android-output-path
+      .opt()
+      .name("androidOutputPath")
+      .title("android output path")
+      .long("android-output-path")
+      .end()
+      // --ios-output-path
+      .opt()
+      .name("iosOutputPath")
+      .title("ios-output path")
+      .long("ios-output-path")
       .end()
       .act(resolve)
       .run(args.slice(2))

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -26,7 +26,7 @@ const iosIcons = [
 ];
 
 export interface Config extends output.OutputConfig {
-  iconsetDir: string;
+  iosOutputPath: string;
 }
 export async function* generate(
   config: Partial<Config>,
@@ -40,7 +40,7 @@ export async function* generate(
 
 async function getConfig(config: Partial<Config>): Promise<Config> {
   return {
-    iconsetDir: config.iconsetDir || (await getIconsetDir()),
+    iosOutputPath: config.iosOutputPath || (await getIconsetDir()),
     force: config.force || false
   };
 }
@@ -75,7 +75,7 @@ async function* generateImages(
       cropSize: input.inputContentSize
     },
     iosIcons.map((icon) => ({
-      filePath: path.join(config.iconsetDir, getIconFilename(icon)),
+      filePath: path.join(config.iosOutputPath, getIconFilename(icon)),
       flattenAlpha: icon.flattenAlpha,
       outputSize: icon.size * icon.scale,
       force: config.force
@@ -84,7 +84,7 @@ async function* generateImages(
 }
 
 async function* generateManifest(config: Config): AsyncIterable<string> {
-  const fileName = path.join(config.iconsetDir, "Contents.json");
+  const fileName = path.join(config.iosOutputPath, "Contents.json");
   yield* output.ensureFileContents(
     fileName,
     {


### PR DESCRIPTION
Fantastic library, thanks for creating this! I used it to generate the default icons for my app,
but I've got multiple flavors/targets in order to push native builds that are wired to different backends,
and I want to have different icons for each (e.g., bright red look out for "Dev", normal for "Prod" etc)

this takes the existing support for android and ios output directories and
exposes it through the config interface with friendly names so that apps with
multiple android variants and multiple ios targets can drop their icons in the
right directories

What do you think?