### PR TITLE
fix adaptive icon default fill color

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -298,7 +298,10 @@ async function* generateAdaptiveIconLayerVd(
   const vdData = await svg2vectordrawable(
     imageData.image.data.toString("utf-8"),
     {
-      strict: true
+      // Fail on unsupported elements, so that we fall back to PNG rendering
+      strict: true,
+      // Use same default fill behaviour as in SVG spec
+      fillBlack: true
     }
   );
   yield* output.ensureFileContents(


### PR DESCRIPTION
Fixes issue where SVG elements with no `fill` attribute would produce `fill="none"` in the adaptive icon, instead of the default SVG behaviour of filling in black.