### PR TITLE
update svg2vectordrawable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,9 +2570,9 @@
       "dev": true
     },
     "@types/q": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
-      "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
+      "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
     "@types/sharp": {
       "version": "0.30.1",
@@ -3545,9 +3545,9 @@
       }
     },
     "dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -6919,9 +6919,9 @@
       }
     },
     "svg2vectordrawable": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/svg2vectordrawable/-/svg2vectordrawable-2.8.4.tgz",
-      "integrity": "sha512-YeSv2av27WFb7U0NXp5evG5ff4gfP9AdJ41ajyOYa6WKtHX8idQGVZq8z2zk/FWGVZ4zTIzCr1zeemEnvNOZCw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/svg2vectordrawable/-/svg2vectordrawable-2.8.5.tgz",
+      "integrity": "sha512-VoTJ08MLxDB/f1trMB50kqrSpTxQWj+5DlE1xc++WL+/uPJrDyhvQ3/438/YA7BJVudeVu/JLz+q6P4DGrm+ow==",
       "requires": {
         "coa": "^2.0.2",
         "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "^7.2.0",
     "fs-extra": ">=3.0.0",
     "sharp": ">=0.23.0",
-    "svg2vectordrawable": "2.8.4"
+    "svg2vectordrawable": "2.8.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.6",


### PR DESCRIPTION
Fixes issues with adaptive icons falling back to PNG instead of using vector drawables.