### PR TITLE
refactor: move logger implementation to CLI and improve logging

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,8 +2,8 @@
 import * as fse from "fs-extra";
 
 import * as reactNativeSvgAppIcon from "../lib";
-import { createLogger } from "../lib/util/logger";
 import { readConfig } from "./config";
+import { createLogger } from "./logger";
 
 const supportedPlatforms: reactNativeSvgAppIcon.Platform[] = ["android", "ios"];
 
@@ -13,7 +13,7 @@ export async function main(args: string[] = []): Promise<void> {
 	// Create logger from config
 	const logger = createLogger(resolvedConfig.logLevel);
 
-	logger.info("Running react-native-svg-app-icon");
+	logger?.info("Running react-native-svg-app-icon");
 
 	if (!(await fse.pathExists(resolvedConfig.foregroundPath))) {
 		throw Error(
@@ -48,9 +48,9 @@ export async function main(args: string[] = []): Promise<void> {
 	const generatedFiles = reactNativeSvgAppIcon.generate(config, logger);
 
 	for await (const file of generatedFiles) {
-		logger.info(`Wrote ${file}`);
+		logger?.info(`Wrote ${file}`);
 	}
-	logger.info("Done");
+	logger?.info("Done");
 }
 
 if (require.main === module) {

--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -1,0 +1,51 @@
+import type { Logger } from "../lib/util/logger";
+
+enum LogLevelValues {
+	error = 1,
+	warn = 2,
+	info = 3,
+	debug = 4,
+}
+
+type LogLevel = "silent" | keyof typeof LogLevelValues;
+
+/**
+ * Create a logger instance with the specified log level
+ */
+export function createLogger(level: LogLevel = "info"): Logger | undefined {
+	if (level === "silent") {
+		return undefined;
+	}
+
+	const currentLevel = LogLevelValues[level];
+
+	function shouldLog(messageLevel: keyof typeof LogLevelValues): boolean {
+		return LogLevelValues[messageLevel] <= currentLevel;
+	}
+
+	return {
+		error(message: string): void {
+			if (shouldLog("error")) {
+				console.error(message);
+			}
+		},
+
+		warn(message: string): void {
+			if (shouldLog("warn")) {
+				console.warn(message);
+			}
+		},
+
+		info(message: string): void {
+			if (shouldLog("info")) {
+				console.log(message);
+			}
+		},
+
+		debug(message: string): void {
+			if (shouldLog("debug")) {
+				console.debug(message);
+			}
+		},
+	};
+}

--- a/src/lib/android/adaptive/adaptive-icons.test.ts
+++ b/src/lib/android/adaptive/adaptive-icons.test.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { beforeAll, describe, it } from "vitest";
 
 import { cleanupTestOutputs } from "../../../../test/utils/cleanup";
-import { logger, makeContext } from "../../../../test/utils/context";
+import { makeContext } from "../../../../test/utils/context";
 import { verifyGeneratedFiles } from "../../../../test/utils/file-comparison";
 import * as input from "../../util/input";
 import type { Config } from "../config";
@@ -39,7 +39,7 @@ describe("android/adaptive-icons", () => {
 					),
 					foregroundPath: path.join(testAssetsPath, "react-icon.svg"),
 				},
-				logger,
+				undefined,
 			);
 
 			const context = makeContext<Config>({
@@ -61,8 +61,10 @@ describe("android/adaptive-icons", () => {
 
 			// Load SVG with unsupported elements (text) that will force PNG fallback
 			const unsupportedFileInput = await input.readIcon(
-				{ foregroundPath: path.join(testAssetsPath, "text-icon.svg") },
-				logger,
+				{
+					foregroundPath: path.join(testAssetsPath, "text-icon.svg"),
+				},
+				undefined,
 			);
 
 			const context = makeContext<Config>({

--- a/src/lib/android/adaptive/adaptive-icons.ts
+++ b/src/lib/android/adaptive/adaptive-icons.ts
@@ -41,7 +41,10 @@ export async function* generateAdaptiveIcons(
 			context,
 		);
 		backgroundResourceType = "drawable";
-	} catch {
+	} catch (error) {
+		context.logger?.warn(
+			`Vector drawable conversion failed for background, falling back to PNG: ${error instanceof Error ? error.message : error}`,
+		);
 		yield* generateAdaptiveIconLayerPng(
 			backgroundImageInput,
 			launcherBackgroundName,
@@ -62,7 +65,10 @@ export async function* generateAdaptiveIcons(
 			context,
 		);
 		foregroundResourceType = "drawable";
-	} catch {
+	} catch (error) {
+		context.logger?.warn(
+			`Vector drawable conversion failed for foreground, falling back to PNG: ${error instanceof Error ? error.message : error}`,
+		);
 		yield* generateAdaptiveIconLayerPng(
 			foregroundImageInput,
 			launcherForegroundName,

--- a/src/lib/android/adaptive/vector-drawable.test.ts
+++ b/src/lib/android/adaptive/vector-drawable.test.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { cleanupTestOutput } from "../../../../test/utils/cleanup";
-import { logger, makeContext } from "../../../../test/utils/context";
+import { makeContext } from "../../../../test/utils/context";
 import { verifyGeneratedFiles } from "../../../../test/utils/file-comparison";
 import * as input from "../../util/input";
 import type { Config } from "../config";
@@ -29,8 +29,10 @@ describe("android/vector-drawable", () => {
 		it("generates vector drawable XML matching expected output", async () => {
 			// Load test icon
 			const fileInput = await input.readIcon(
-				{ foregroundPath: path.join(testAssetsPath, "react-icon.svg") },
-				logger,
+				{
+					foregroundPath: path.join(testAssetsPath, "react-icon.svg"),
+				},
+				undefined,
 			);
 
 			const baseDir = assetsPath;
@@ -62,8 +64,10 @@ describe("android/vector-drawable", () => {
 
 			// Load SVG with text element (unsupported in vector drawable)
 			const unsupportedFileInput = await input.readIcon(
-				{ foregroundPath: path.join(testAssetsPath, "text-icon.svg") },
-				logger,
+				{
+					foregroundPath: path.join(testAssetsPath, "text-icon.svg"),
+				},
+				undefined,
 			);
 
 			const context = makeContext<Config>({

--- a/src/lib/android/index.ts
+++ b/src/lib/android/index.ts
@@ -11,6 +11,9 @@ export async function* generate(
 	context: Context<Config>,
 	fileInput: input.FileInput,
 ): AsyncIterable<string> {
+	context.logger?.debug(
+		`Android output path: ${context.config.androidOutputPath}`,
+	);
 	yield* generateLegacySquareIcons(fileInput, context);
 	yield* generateLegacyRoundIcons(fileInput, context);
 	yield* generateAdaptiveIcons(fileInput, context);

--- a/src/lib/android/legacy/round-icons.test.ts
+++ b/src/lib/android/legacy/round-icons.test.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { beforeAll, beforeEach, describe, it } from "vitest";
 
 import { cleanupTestOutput } from "../../../../test/utils/cleanup";
-import { logger, makeContext } from "../../../../test/utils/context";
+import { makeContext } from "../../../../test/utils/context";
 import { verifyGeneratedFiles } from "../../../../test/utils/file-comparison";
 import * as input from "../../util/input";
 import type { Config } from "../config";
@@ -32,7 +32,7 @@ describe("android/legacy/round-icons", () => {
 				backgroundPath: path.join(testAssetsPath, "square-icon-background.svg"),
 				foregroundPath: path.join(testAssetsPath, "square-icon-foreground.svg"),
 			},
-			logger,
+			undefined,
 		);
 	});
 

--- a/src/lib/android/legacy/square-icons.test.ts
+++ b/src/lib/android/legacy/square-icons.test.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { beforeAll, beforeEach, describe, it } from "vitest";
 
 import { cleanupTestOutput } from "../../../../test/utils/cleanup";
-import { logger, makeContext } from "../../../../test/utils/context";
+import { makeContext } from "../../../../test/utils/context";
 import { verifyGeneratedFiles } from "../../../../test/utils/file-comparison";
 import * as input from "../../util/input";
 import type { Config } from "../config";
@@ -32,7 +32,7 @@ describe("android/legacy/square-icons", () => {
 				backgroundPath: path.join(testAssetsPath, "square-icon-background.svg"),
 				foregroundPath: path.join(testAssetsPath, "square-icon-foreground.svg"),
 			},
-			logger,
+			undefined,
 		);
 	});
 

--- a/src/lib/cache/index.test.ts
+++ b/src/lib/cache/index.test.ts
@@ -28,6 +28,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 
 				expect(await session.isUpToDate(outputFile)).toBe(false);
@@ -46,6 +47,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				session1.recordBuffer(outputFile, await fse.readFile(outputFile));
 				await session1.flush();
@@ -57,6 +59,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: true,
+					logger: undefined,
 				});
 				expect(await session2.isUpToDate(outputFile)).toBe(false);
 			});
@@ -74,6 +77,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				session1.recordBuffer(outputFile, await fse.readFile(outputFile));
 				await session1.flush();
@@ -85,6 +89,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				expect(await session2.isUpToDate(outputFile)).toBe(true);
 			});
@@ -103,6 +108,7 @@ describe("cache", () => {
 						background: originalBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				session1.recordBuffer(output1, await fse.readFile(output1));
 				session1.recordBuffer(output2, await fse.readFile(output2));
@@ -118,6 +124,7 @@ describe("cache", () => {
 						background: changedBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				expect(await session2.isUpToDate(output1)).toBe(false);
 				expect(await session2.isUpToDate(output2)).toBe(false);
@@ -136,12 +143,13 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				session1.recordBuffer(outputFile, await fse.readFile(outputFile));
 				await session1.flush();
 
 				// Tamper with the cached version to simulate an upgrade
-				const cacheData = await storage.readCacheData();
+				const cacheData = await storage.readCacheData(undefined);
 				await storage.writeCacheData({
 					...cacheData,
 					packageVersion: "0.0.0",
@@ -154,6 +162,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				expect(await session2.isUpToDate(outputFile)).toBe(false);
 			});
@@ -172,6 +181,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				session1.recordBuffer(output1, await fse.readFile(output1));
 				session1.recordBuffer(output2, await fse.readFile(output2));
@@ -186,6 +196,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				expect(await session2.isUpToDate(output1)).toBe(false);
 				expect(await session2.isUpToDate(output2)).toBe(true);
@@ -204,6 +215,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				session1.recordBuffer(outputFile, await fse.readFile(outputFile));
 				await session1.flush();
@@ -217,6 +229,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				expect(await session2.isUpToDate(outputFile)).toBe(false);
 			});
@@ -232,6 +245,7 @@ describe("cache", () => {
 				const session1 = new CacheSession({
 					inputFileBuffers: { foreground: fgBuffer, background: bgBuffer },
 					force: false,
+					logger: undefined,
 				});
 				session1.recordBuffer(outputFile, await fse.readFile(outputFile));
 				await session1.flush();
@@ -240,6 +254,7 @@ describe("cache", () => {
 				const session2 = new CacheSession({
 					inputFileBuffers: { foreground: fgBuffer, background: bgBuffer },
 					force: false,
+					logger: undefined,
 				});
 				expect(await session2.isUpToDate(outputFile)).toBe(true);
 
@@ -255,6 +270,7 @@ describe("cache", () => {
 						background: bgBufferChanged,
 					},
 					force: false,
+					logger: undefined,
 				});
 				expect(await session3.isUpToDate(outputFile)).toBe(false);
 			});
@@ -272,6 +288,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				session1.recordBuffer(outputFile, await fse.readFile(outputFile));
 				await session1.flush();
@@ -283,6 +300,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				expect(await session2.isUpToDate(outputFile)).toBe(true);
 				// Intentionally omit session2.recordBuffer() to simulate a skipped file
@@ -295,6 +313,7 @@ describe("cache", () => {
 						background: inputBuffer,
 					},
 					force: false,
+					logger: undefined,
 				});
 				expect(await session3.isUpToDate(outputFile)).toBe(true);
 			});

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,6 +1,7 @@
 import * as crypto from "node:crypto";
 import * as fse from "fs-extra";
 import type { InputFileBuffers } from "../util/input";
+import type { Logger } from "../util/logger";
 import { getPackageVersion } from "../util/version";
 import * as storage from "./storage";
 
@@ -34,6 +35,7 @@ async function hashFile(filePath: string): Promise<string | null> {
 export class CacheSession {
 	private readonly inputFileBuffers: InputFileBuffers;
 	private readonly force: boolean;
+	private readonly logger: Logger | undefined;
 
 	/** In-memory record of output hashes written this run. */
 	private newOutputHashes: Record<string, string> = {};
@@ -41,9 +43,15 @@ export class CacheSession {
 	constructor({
 		inputFileBuffers,
 		force,
-	}: { inputFileBuffers: InputFileBuffers; force: boolean }) {
+		logger,
+	}: {
+		inputFileBuffers: InputFileBuffers;
+		force: boolean;
+		logger: Logger | undefined;
+	}) {
 		this.inputFileBuffers = inputFileBuffers;
 		this.force = force;
+		this.logger = logger;
 	}
 
 	/**
@@ -52,20 +60,30 @@ export class CacheSession {
 	 */
 	async isUpToDate(outputFilePath: string): Promise<boolean> {
 		if (this.force) {
+			this.logger?.debug(`Cache miss for ${outputFilePath}: force flag is set`);
 			return false;
 		}
 
 		if (await this.hasPackageVersionChanged()) {
+			this.logger?.debug(
+				`Cache miss for ${outputFilePath}: package version changed`,
+			);
 			return false;
 		}
 
 		if (await this.haveInputsChanged()) {
+			this.logger?.debug(
+				`Cache miss for ${outputFilePath}: input files changed`,
+			);
 			return false;
 		}
 
 		const cache = await this.loadCache();
 		const cachedOutputHash = cache.outputs[outputFilePath];
 		if (!cachedOutputHash) {
+			this.logger?.debug(
+				`Cache miss for ${outputFilePath}: no cached hash found`,
+			);
 			return false;
 		}
 
@@ -74,6 +92,9 @@ export class CacheSession {
 			this.newOutputHashes[outputFilePath] = cachedOutputHash;
 			return true;
 		}
+		this.logger?.debug(
+			`Cache miss for ${outputFilePath}: output file changed on disk`,
+		);
 		return false;
 	}
 
@@ -139,7 +160,7 @@ export class CacheSession {
 	/** Lazily loaded from disk, then kept in memory. */
 	private cacheDataPromise?: Promise<storage.CacheData>;
 	private loadCache(): Promise<storage.CacheData> {
-		this.cacheDataPromise ??= storage.readCacheData();
+		this.cacheDataPromise ??= storage.readCacheData(this.logger);
 		return this.cacheDataPromise;
 	}
 }

--- a/src/lib/cache/storage.test.ts
+++ b/src/lib/cache/storage.test.ts
@@ -7,7 +7,7 @@ const it = base.extend({ tmpDir });
 
 describe("storage", () => {
 	it("returns written data after write", async ({ tmpDir: _tmpDir }) => {
-		expect(await readCacheData()).toEqual({ inputs: {}, outputs: {} });
+		expect(await readCacheData(undefined)).toEqual({ inputs: {}, outputs: {} });
 
 		const data = {
 			inputs: { "icon.svg": "abc123" },
@@ -16,6 +16,6 @@ describe("storage", () => {
 
 		await writeCacheData(data);
 
-		expect(await readCacheData()).toEqual(data);
+		expect(await readCacheData(undefined)).toEqual(data);
 	});
 });

--- a/src/lib/cache/storage.ts
+++ b/src/lib/cache/storage.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type } from "arktype";
 import * as fse from "fs-extra";
+import type { Logger } from "../util/logger";
 import { memoize } from "../util/memoize";
 
 const cacheDataType = type({
@@ -32,11 +33,16 @@ const getCachePath = memoize((): string => {
 	);
 });
 
-export async function readCacheData(): Promise<CacheData> {
+export async function readCacheData(
+	logger: Logger | undefined,
+): Promise<CacheData> {
 	try {
 		const raw: unknown = await fse.readJson(getCachePath());
 		return cacheDataType.assert(raw);
-	} catch {
+	} catch (error) {
+		logger?.debug(
+			`Could not read cache at ${getCachePath()}: ${error instanceof Error ? error.message : error}`,
+		);
 		return { inputs: {}, outputs: {} };
 	}
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,24 +8,34 @@ import type { Logger } from "./util/logger";
 
 export type { Config, Platform };
 
+/**
+ * Generate platform-specific app icons from SVG source files.
+ *
+ * @param config - Icon paths, target platforms, and output settings.
+ * @param logger - Optional logger for progress and diagnostic messages.
+ *   When `undefined`, all logging is disabled.
+ */
 export async function* generate(
 	config: Config,
-	logger: Logger,
+	logger: Logger | undefined,
 ): AsyncIterable<string> {
 	const iconInput = await input.readIcon(config.icon, logger);
 
 	const cache = new CacheSession({
 		inputFileBuffers: iconInput.fileBuffers,
 		force: config.force ?? false,
+		logger,
 	});
 
 	const context: Context<Config> = { config, logger, cache };
 
 	try {
 		if (config.platforms.includes("android")) {
+			logger?.info("Generating Android icons");
 			yield* android.generate(context, iconInput);
 		}
 		if (config.platforms.includes("ios")) {
+			logger?.info("Generating iOS icons");
 			yield* ios.generate(context, iconInput);
 		}
 	} finally {

--- a/src/lib/ios/config.test.ts
+++ b/src/lib/ios/config.test.ts
@@ -11,9 +11,12 @@ describe("ios/config", () => {
 	describe("getConfig", () => {
 		it("uses provided iosOutputPath", async ({ tmpDir: _tmpDir }) => {
 			const customPath = path.join("/custom", "path");
-			const config = await getConfig({
-				iosOutputPath: customPath,
-			});
+			const config = await getConfig(
+				{
+					iosOutputPath: customPath,
+				},
+				undefined,
+			);
 
 			expect(config.iosOutputPath).toBe(customPath);
 		});
@@ -24,7 +27,7 @@ describe("ios/config", () => {
 			// Create Images.xcassets directory structure
 			await fse.ensureDir(path.join("ios", "MyProject", "Images.xcassets"));
 
-			const config = await getConfig({});
+			const config = await getConfig({}, undefined);
 
 			expect(config.iosOutputPath).toBe(
 				path.join("ios", "MyProject", "Images.xcassets", "AppIcon.appiconset"),
@@ -36,7 +39,7 @@ describe("ios/config", () => {
 		}) => {
 			await fse.ensureDir(path.join("ios", "My App", "Images.xcassets"));
 
-			const config = await getConfig({});
+			const config = await getConfig({}, undefined);
 
 			expect(config.iosOutputPath).toBe(
 				path.join("ios", "My App", "Images.xcassets", "AppIcon.appiconset"),
@@ -50,7 +53,7 @@ describe("ios/config", () => {
 			await fse.ensureDir(path.join("ios", "My", "Images.xcassets"));
 			await fse.ensureDir(path.join("ios", "My App", "Images.xcassets"));
 
-			const config = await getConfig({ appName: "My App" });
+			const config = await getConfig({ appName: "My App" }, undefined);
 
 			expect(config.iosOutputPath).toBe(
 				path.join("ios", "My App", "Images.xcassets", "AppIcon.appiconset"),
@@ -62,9 +65,12 @@ describe("ios/config", () => {
 		}) => {
 			await fse.ensureDir(path.join("ios", "ActualProject", "Images.xcassets"));
 
-			const config = await getConfig({
-				appName: "DifferentName",
-			});
+			const config = await getConfig(
+				{
+					appName: "DifferentName",
+				},
+				undefined,
+			);
 
 			expect(config.iosOutputPath).toBe(
 				path.join(
@@ -82,7 +88,7 @@ describe("ios/config", () => {
 			// Create ios directory but no Images.xcassets
 			await fse.ensureDir(path.join("ios", "MyProject"));
 
-			await expect(getConfig({})).rejects.toThrow(
+			await expect(getConfig({}, undefined)).rejects.toThrow(
 				"No Images.xcassets found under ios/ subdirectories",
 			);
 		});

--- a/src/lib/ios/config.ts
+++ b/src/lib/ios/config.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import * as fse from "fs-extra";
+import type { Logger } from "../util/logger";
 import type { Optional } from "../util/optional";
 
 interface PlatformConfig {
@@ -12,15 +13,22 @@ export type ResolvedConfig = PlatformConfig;
 
 export async function getConfig(
 	config: PartialConfig,
+	logger: Logger | undefined,
 ): Promise<ResolvedConfig> {
+	if (config.iosOutputPath) {
+		logger?.debug(`Using configured iOS output path: ${config.iosOutputPath}`);
+	}
 	return {
 		...config,
 		iosOutputPath:
-			config.iosOutputPath || (await getIconsetDir(config.appName)),
+			config.iosOutputPath || (await getIconsetDir(config.appName, logger)),
 	};
 }
 
-async function getIconsetDir(appName?: string): Promise<string> {
+async function getIconsetDir(
+	appName: string | undefined,
+	logger: Logger | undefined,
+): Promise<string> {
 	// Prefer the directory matching the app name from app.json, to avoid
 	// picking a wrong subdirectory when multiple matches exist (e.g. "My"
 	// vs "My App").
@@ -35,7 +43,11 @@ async function getIconsetDir(appName?: string): Promise<string> {
 			(await fse.pathExists(preferredPath)) &&
 			(await fse.stat(preferredPath)).isDirectory()
 		) {
-			return path.join(preferredPath, "AppIcon.appiconset");
+			const result = path.join(preferredPath, "AppIcon.appiconset");
+			logger?.debug(
+				`Auto-detected iOS output path from app name "${appName}": ${result}`,
+			);
+			return result;
 		}
 	}
 
@@ -45,7 +57,11 @@ async function getIconsetDir(appName?: string): Promise<string> {
 			(await fse.pathExists(testPath)) &&
 			(await fse.stat(testPath)).isDirectory()
 		) {
-			return path.join(testPath, "AppIcon.appiconset");
+			const result = path.join(testPath, "AppIcon.appiconset");
+			logger?.debug(
+				`Auto-detected iOS output path from directory scan: ${result}`,
+			);
+			return result;
 		}
 	}
 

--- a/src/lib/ios/index.test.ts
+++ b/src/lib/ios/index.test.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { beforeAll, beforeEach, describe, it } from "vitest";
 
 import { cleanupTestOutputs } from "../../../test/utils/cleanup";
-import { logger, makeContext } from "../../../test/utils/context";
+import { makeContext } from "../../../test/utils/context";
 import { verifyGeneratedFiles } from "../../../test/utils/file-comparison";
 import * as input from "../util/input";
 import { generate, type PartialConfig } from "./index";
@@ -32,7 +32,7 @@ describe("ios/index", () => {
 				backgroundPath: path.join(testAssetsPath, "react-icon-background.svg"),
 				foregroundPath: path.join(testAssetsPath, "react-icon.svg"),
 			},
-			logger,
+			undefined,
 		);
 	});
 

--- a/src/lib/ios/index.ts
+++ b/src/lib/ios/index.ts
@@ -34,7 +34,7 @@ export async function* generate(
 ): AsyncIterable<string> {
 	const resolvedContext: Context<ResolvedConfig> = {
 		...context,
-		config: await getConfig(context.config),
+		config: await getConfig(context.config, context.logger),
 	};
 
 	yield* generateImages(resolvedContext, fileInput);

--- a/src/lib/util/context.ts
+++ b/src/lib/util/context.ts
@@ -11,6 +11,6 @@ import type { Logger } from "./logger";
  */
 export interface Context<Config = unknown> {
 	config: Config;
-	logger: Logger;
+	logger: Logger | undefined;
 	cache: CacheSession;
 }

--- a/src/lib/util/input.ts
+++ b/src/lib/util/input.ts
@@ -68,7 +68,7 @@ interface BackgroundImageData extends ImageData {
 
 export async function readIcon(
 	config: Optional<Config>,
-	logger: Logger,
+	logger: Logger | undefined,
 ): Promise<FileInput> {
 	const fullConfig = getConfig(config);
 
@@ -98,13 +98,13 @@ function getConfig(config: Optional<Config>): Config {
 async function loadData(
 	config: Config,
 	buffers: InputFileBuffers,
-	logger: Logger,
+	logger: Logger | undefined,
 ): Promise<InputData> {
 	if (config.backgroundPath) {
-		logger.info("Reading background file", config.backgroundPath);
+		logger?.debug(`Reading background file ${config.backgroundPath}`);
 	}
 	if (config.foregroundPath) {
-		logger.info("Reading file", config.foregroundPath);
+		logger?.debug(`Reading foreground file ${config.foregroundPath}`);
 	}
 
 	const [backgroundImageData, foregroundImageData] = await Promise.all([

--- a/src/lib/util/logger.ts
+++ b/src/lib/util/logger.ts
@@ -1,60 +1,15 @@
 /**
- * Simple logger with configurable log levels.
- * Supports: silent, error, warn, info, debug
- * Default: info
+ * Logger type contract with methods for each log level.
+ *
+ * Implementations decide how (and whether) to handle each level.
  */
-
-enum LogLevelValues {
-	silent = 0,
-	error = 1,
-	warn = 2,
-	info = 3,
-	debug = 4,
-}
-
-export type LogLevel = keyof typeof LogLevelValues;
-
 export type Logger = {
-	[level in LogLevel]: (...args: unknown[]) => void;
+	/** An unrecoverable situation that prevents the operation from completing. */
+	error(message: string): void;
+	/** A potential issue that does not prevent completion but may need attention. */
+	warn(message: string): void;
+	/** High-level progress updates for normal operation (e.g. files written). */
+	info(message: string): void;
+	/** Detailed diagnostic information useful during development or troubleshooting. */
+	debug(message: string): void;
 };
-
-/**
- * Create a logger instance with the specified log level
- */
-export function createLogger(level: LogLevel = "info"): Logger {
-	const currentLevel = LogLevelValues[level];
-
-	function shouldLog(messageLevel: LogLevel): boolean {
-		return LogLevelValues[messageLevel] <= currentLevel;
-	}
-
-	return {
-		error(...args: unknown[]): void {
-			if (shouldLog("error")) {
-				console.error(...args);
-			}
-		},
-
-		warn(...args: unknown[]): void {
-			if (shouldLog("warn")) {
-				console.warn(...args);
-			}
-		},
-
-		info(...args: unknown[]): void {
-			if (shouldLog("info")) {
-				console.log(...args);
-			}
-		},
-
-		debug(...args: unknown[]): void {
-			if (shouldLog("debug")) {
-				console.debug(...args);
-			}
-		},
-
-		silent(..._args: unknown[]): void {
-			// do nothing
-		},
-	};
-}

--- a/src/lib/util/output.ts
+++ b/src/lib/util/output.ts
@@ -76,9 +76,10 @@ export async function* generateFile(
 	contentProvider:
 		| (() => string | Record<string, unknown> | Buffer)
 		| (() => Promise<string | Record<string, unknown> | Buffer>),
-	{ cache }: Context,
+	{ cache, logger }: Context,
 ): AsyncIterable<string> {
 	if (await cache.isUpToDate(path)) {
+		logger?.debug(`Skipping ${path} (up to date)`);
 		return;
 	}
 

--- a/test/utils/context.ts
+++ b/test/utils/context.ts
@@ -1,8 +1,5 @@
 import { CacheSession } from "../../src/lib/cache";
 import type { Context } from "../../src/lib/util/context";
-import { createLogger } from "../../src/lib/util/logger";
-
-export const logger = createLogger("silent");
 
 export const cache = new CacheSession({
 	inputFileBuffers: {
@@ -10,6 +7,7 @@ export const cache = new CacheSession({
 		background: Buffer.from(""),
 	},
 	force: true,
+	logger: undefined,
 });
 
 /**
@@ -27,5 +25,5 @@ export const cache = new CacheSession({
  * ```
  */
 export function makeContext<C>(config: C): Context<C> {
-	return { config, logger, cache };
+	return { config, cache, logger: undefined };
 }


### PR DESCRIPTION
## Summary

Separates the logger type contract (lib) from the logger implementation (CLI), making the lib's logging interface portable for other consumers like Expo. Adds structured logging throughout the generation pipeline.

### Logger refactoring

- **`src/lib/util/logger.ts`** now exports only the `Logger` type with explicit per-level methods accepting a single `string` parameter, matching the common interface of `console`, winston, pino, etc.
- **`src/cli/logger.ts`** (new) contains `createLogger` with `LogLevel` support. Returns `undefined` for `"silent"` level.
- Logger is optional everywhere — `undefined` disables all logging via optional chaining.
- Test utils no longer import CLI code; they simply omit the logger.

### Logging coverage

| Level | Where | What |
|-------|-------|------|
| **info** | `lib/index.ts` | Platform generation start |
| **info** | `cli/index.ts` | File output paths (existing) |
| **warn** | `android/adaptive-icons.ts` | Vector drawable conversion failure, PNG fallback |
| **debug** | `ios/config.ts` | How iOS output path was determined |
| **debug** | `android/index.ts` | Android output path |
| **debug** | `util/input.ts` | Input file reads |
| **debug** | `util/output.ts` | Cache skips |
| **debug** | `cache/index.ts` | Cache miss reasons |
| **debug** | `cache/storage.ts` | Cache read failures |