### PR TITLE
Move input validation from CLI into lib

### DIFF
--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -2,16 +2,31 @@ import * as fse from "fs-extra";
 import { it as base, describe, expect } from "vitest";
 
 import { tmpDir } from "../../test/utils/tmp-dir";
-import { readConfig } from "./config";
+import { resolveConfig } from "./config";
 
 const it = base.extend({ tmpDir });
 
 describe("cli/config", () => {
-	describe("readConfig", () => {
+	describe("resolveConfig", () => {
 		it("returns default config when no app.json or arguments", async ({
 			tmpDir: _tmpDir,
 		}) => {
-			const resolvedConfig = await readConfig(["node", "script.js"]);
+			const resolvedConfig = await resolveConfig(["node", "script.js"]);
+
+			expect(resolvedConfig).toEqual({
+				foregroundPath: "./icon.svg",
+				platforms: ["android", "ios"],
+				force: false,
+				androidOutputPath: "./android/app/src/main/res",
+				logLevel: "info",
+			});
+		});
+
+		it("includes default background path when file exists", async ({
+			tmpDir: _tmpDir,
+		}) => {
+			await fse.writeFile("./icon-background.svg", "<svg/>");
+			const resolvedConfig = await resolveConfig(["node", "script.js"]);
 
 			expect(resolvedConfig).toEqual({
 				backgroundPath: "./icon-background.svg",
@@ -31,11 +46,10 @@ describe("cli/config", () => {
 				displayName: "Test Application",
 			});
 
-			const resolvedConfig = await readConfig(["node", "script.js"]);
+			const resolvedConfig = await resolveConfig(["node", "script.js"]);
 
 			expect(resolvedConfig).toMatchObject({
 				appName: "TestApp",
-				backgroundPath: "./icon-background.svg",
 				foregroundPath: "./icon.svg",
 			});
 		});
@@ -53,7 +67,7 @@ describe("cli/config", () => {
 				},
 			});
 
-			const resolvedConfig = await readConfig(["node", "script.js"]);
+			const resolvedConfig = await resolveConfig(["node", "script.js"]);
 
 			expect(resolvedConfig).toEqual({
 				appName: "TestApp",
@@ -76,7 +90,7 @@ describe("cli/config", () => {
 				},
 			});
 
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--foreground-path",
@@ -98,12 +112,11 @@ describe("cli/config", () => {
 				},
 			});
 
-			const resolvedConfig = await readConfig(["node", "script.js"]);
+			const resolvedConfig = await resolveConfig(["node", "script.js"]);
 
 			expect(resolvedConfig).toMatchObject({
 				logLevel: "debug",
 				platforms: ["ios"],
-				backgroundPath: "./icon-background.svg",
 			});
 		});
 
@@ -116,7 +129,7 @@ describe("cli/config", () => {
 				},
 			});
 
-			await expect(readConfig(["node", "script.js"])).rejects.toThrow(
+			await expect(resolveConfig(["node", "script.js"])).rejects.toThrow(
 				/Invalid app.json/,
 			);
 		});
@@ -130,7 +143,7 @@ describe("cli/config", () => {
 				},
 			});
 
-			await expect(readConfig(["node", "script.js"])).rejects.toThrow(
+			await expect(resolveConfig(["node", "script.js"])).rejects.toThrow(
 				/Invalid app.json/,
 			);
 		});
@@ -145,7 +158,7 @@ describe("cli/config", () => {
 				},
 			});
 
-			await expect(readConfig(["node", "script.js"])).rejects.toThrow(
+			await expect(resolveConfig(["node", "script.js"])).rejects.toThrow(
 				/Invalid app.json/,
 			);
 		});
@@ -155,13 +168,13 @@ describe("cli/config", () => {
 		}) => {
 			await fse.writeFile("app.json", "invalid json {");
 
-			await expect(readConfig(["node", "script.js"])).rejects.toThrow();
+			await expect(resolveConfig(["node", "script.js"])).rejects.toThrow();
 		});
 
 		it("reads background-path from CLI arguments", async ({
 			tmpDir: _tmpDir,
 		}) => {
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--background-path",
@@ -176,7 +189,7 @@ describe("cli/config", () => {
 		it("reads foreground-path from CLI arguments", async ({
 			tmpDir: _tmpDir,
 		}) => {
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--foreground-path",
@@ -191,7 +204,7 @@ describe("cli/config", () => {
 		it("reads platforms from CLI arguments with multiple values", async ({
 			tmpDir: _tmpDir,
 		}) => {
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--platforms",
@@ -207,7 +220,7 @@ describe("cli/config", () => {
 		it("reads platforms from CLI arguments with single value", async ({
 			tmpDir: _tmpDir,
 		}) => {
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--platforms",
@@ -220,7 +233,11 @@ describe("cli/config", () => {
 		});
 
 		it("reads force flag from CLI arguments", async ({ tmpDir: _tmpDir }) => {
-			const resolvedConfig = await readConfig(["node", "script.js", "--force"]);
+			const resolvedConfig = await resolveConfig([
+				"node",
+				"script.js",
+				"--force",
+			]);
 
 			expect(resolvedConfig).toMatchObject({
 				force: true,
@@ -230,7 +247,7 @@ describe("cli/config", () => {
 		it("reads short force flag from CLI arguments", async ({
 			tmpDir: _tmpDir,
 		}) => {
-			const resolvedConfig = await readConfig(["node", "script.js", "-f"]);
+			const resolvedConfig = await resolveConfig(["node", "script.js", "-f"]);
 
 			expect(resolvedConfig).toMatchObject({
 				force: true,
@@ -240,7 +257,7 @@ describe("cli/config", () => {
 		it("reads android-output-path from CLI arguments", async ({
 			tmpDir: _tmpDir,
 		}) => {
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--android-output-path",
@@ -255,7 +272,7 @@ describe("cli/config", () => {
 		it("reads ios-output-path from CLI arguments", async ({
 			tmpDir: _tmpDir,
 		}) => {
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--ios-output-path",
@@ -268,7 +285,7 @@ describe("cli/config", () => {
 		});
 
 		it("reads log-level from CLI arguments", async ({ tmpDir: _tmpDir }) => {
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--log-level",
@@ -281,7 +298,7 @@ describe("cli/config", () => {
 		});
 
 		it("reads multiple CLI arguments together", async ({ tmpDir: _tmpDir }) => {
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--background-path",
@@ -317,7 +334,7 @@ describe("cli/config", () => {
 				},
 			});
 
-			const resolvedConfig = await readConfig([
+			const resolvedConfig = await resolveConfig([
 				"node",
 				"script.js",
 				"--foreground-path",

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -73,8 +73,8 @@ export type ResolvedConfig = Omit<ConfigSchema, "backgroundPath"> & {
  * Resolve and merge configuration from all sources:
  * defaults → app.json → command-line arguments
  *
- * Also resolves the background icon path: if explicitly provided it must
- * exist, otherwise falls back to the default path if present on disk.
+ * Also resolves the background icon path: an explicitly provided path is
+ * used as-is, otherwise the default path is used when it is present on disk.
  */
 export async function resolveConfig(
 	args: string[] = [],

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -56,21 +56,43 @@ const configSchema = type({
 		.default("info"),
 });
 
+type ConfigSchema = typeof configSchema.infer;
+
+const { backgroundPath: defaultBackgroundPath, ...defaultConfig } =
+	configSchema.assert({});
+
 /**
  * Fully resolved configuration, merged from defaults, app.json, and CLI arguments.
  */
-export type ResolvedConfig = typeof configSchema.infer & {
+export type ResolvedConfig = Omit<ConfigSchema, "backgroundPath"> & {
+	backgroundPath?: ConfigSchema["backgroundPath"];
 	appName?: typeof appJsonSchema.infer.name;
 };
 
 /**
- * Read and merge configuration from all sources:
+ * Resolve and merge configuration from all sources:
  * defaults → app.json → command-line arguments
+ *
+ * Also resolves the background icon path: if explicitly provided it must
+ * exist, otherwise falls back to the default path if present on disk.
  */
-export async function readConfig(args: string[] = []): Promise<ResolvedConfig> {
+export async function resolveConfig(
+	args: string[] = [],
+): Promise<ResolvedConfig> {
+	const fileConfig = await readAppJsonConfig();
+	const cliConfig = readCliArgs(args);
+
+	const userConfig = {
+		...fileConfig,
+		...cliConfig,
+	};
+
+	const backgroundPath = await resolveBackgroundPath(userConfig.backgroundPath);
+
 	return {
-		...(await readAppJsonConfig()),
-		...readCliArgs(args),
+		...defaultConfig,
+		...userConfig,
+		...(backgroundPath ? { backgroundPath } : {}),
 	};
 }
 
@@ -83,7 +105,7 @@ const appJsonSchema = type({
 	svgAppIcon: configSchema.default(() => ({})),
 });
 
-async function readAppJsonConfig(): Promise<ResolvedConfig> {
+async function readAppJsonConfig(): Promise<Partial<ResolvedConfig>> {
 	let rawAppJson: unknown;
 	try {
 		rawAppJson = await fse.readJson("./app.json");
@@ -96,17 +118,18 @@ async function readAppJsonConfig(): Promise<ResolvedConfig> {
 		}
 	}
 
-	// Validate the app.json structure
-	const result = appJsonSchema(rawAppJson);
-
-	if (result instanceof type.errors) {
-		throw new Error(`Invalid app.json: ${result.summary}`);
+	// Validate the app.json structure, but omit defaults
+	if (appJsonSchema.allows(rawAppJson)) {
+		return {
+			...(rawAppJson.name ? { appName: rawAppJson.name } : {}),
+			...rawAppJson.svgAppIcon,
+		};
+	} else {
+		const result = appJsonSchema(rawAppJson);
+		throw new Error(
+			`Invalid app.json: ${result instanceof type.errors ? result.summary : "Unknown validation error"}`,
+		);
 	}
-
-	return {
-		...(result.name ? { appName: result.name } : {}),
-		...result.svgAppIcon,
-	};
 }
 
 function readCliArgs(args: string[]): Partial<ResolvedConfig> {
@@ -147,4 +170,20 @@ function readCliArgs(args: string[]): Partial<ResolvedConfig> {
 	);
 
 	return userDefinedOptions;
+}
+
+async function resolveBackgroundPath(
+	backgroundPath: string | undefined,
+): Promise<string | undefined> {
+	if (backgroundPath) {
+		return backgroundPath;
+	}
+
+	// No explicit path — use default if it exists on disk
+	if (await fse.pathExists(defaultBackgroundPath)) {
+		return defaultBackgroundPath;
+	}
+
+	// No background icon available — fall back to internal white background
+	return undefined;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,41 +1,19 @@
 #!/usr/bin/env node
-import * as fse from "fs-extra";
-
 import * as reactNativeSvgAppIcon from "../lib";
-import { readConfig } from "./config";
+import { resolveConfig } from "./config";
 import { createLogger } from "./logger";
 
-const supportedPlatforms: reactNativeSvgAppIcon.Platform[] = ["android", "ios"];
-
 export async function main(args: string[] = []): Promise<void> {
-	const resolvedConfig = await readConfig(args);
+	const resolvedConfig = await resolveConfig(args);
 
 	// Create logger from config
 	const logger = createLogger(resolvedConfig.logLevel);
 
 	logger?.info("Running react-native-svg-app-icon");
 
-	if (!(await fse.pathExists(resolvedConfig.foregroundPath))) {
-		throw Error(
-			`Icon is required, but not found at ${resolvedConfig.foregroundPath}`,
-		);
-	}
-
-	resolvedConfig.platforms = resolvedConfig.platforms
-		.map((platform) => platform.toLowerCase())
-		.filter((platform): platform is reactNativeSvgAppIcon.Platform => {
-			if ((supportedPlatforms as string[]).includes(platform)) {
-				return true;
-			} else {
-				throw Error(`Unsupported platform ${platform}`);
-			}
-		});
-
 	const config: reactNativeSvgAppIcon.Config = {
 		icon: {
-			backgroundPath: (await fse.pathExists(resolvedConfig.backgroundPath))
-				? resolvedConfig.backgroundPath
-				: undefined,
+			backgroundPath: resolvedConfig.backgroundPath,
 			foregroundPath: resolvedConfig.foregroundPath,
 		},
 		platforms: resolvedConfig.platforms,

--- a/src/lib/util/input.ts
+++ b/src/lib/util/input.ts
@@ -70,11 +70,21 @@ export async function readIcon(
 	config: Optional<Config>,
 	logger: Logger | undefined,
 ): Promise<FileInput> {
-	const fullConfig = await getConfig(config, logger);
+	const fullConfig = getConfig(config, logger);
 
 	const [backgroundBuffer, foregroundBuffer] = await Promise.all([
-		fse.readFile(fullConfig.backgroundPath),
-		fse.readFile(fullConfig.foregroundPath),
+		fse.readFile(fullConfig.backgroundPath).catch((error) => {
+			throw new Error(
+				`Failed to read background icon at ${fullConfig.backgroundPath}`,
+				{ cause: error },
+			);
+		}),
+		fse.readFile(fullConfig.foregroundPath).catch((error) => {
+			throw new Error(
+				`Icon is required, but not found at ${fullConfig.foregroundPath}`,
+				{ cause: error },
+			);
+		}),
 	]);
 
 	const fileBuffers: InputFileBuffers = {
@@ -88,22 +98,14 @@ export async function readIcon(
 	};
 }
 
-async function getConfig(
+function getConfig(
 	config: Optional<Config>,
 	logger: Logger | undefined,
-): Promise<Config> {
+): Config {
 	const foregroundPath = config.foregroundPath || "./icon.svg";
-
-	if (!(await fse.pathExists(foregroundPath))) {
-		throw new Error(`Icon is required, but not found at ${foregroundPath}`);
-	}
 
 	let backgroundPath: string;
 	if (config.backgroundPath !== undefined) {
-		if (!(await fse.pathExists(config.backgroundPath))) {
-			throw new Error(`Background icon not found at ${config.backgroundPath}`);
-		}
-
 		backgroundPath = config.backgroundPath;
 	} else {
 		logger?.debug(

--- a/src/lib/util/input.ts
+++ b/src/lib/util/input.ts
@@ -70,7 +70,7 @@ export async function readIcon(
 	config: Optional<Config>,
 	logger: Logger | undefined,
 ): Promise<FileInput> {
-	const fullConfig = getConfig(config);
+	const fullConfig = await getConfig(config, logger);
 
 	const [backgroundBuffer, foregroundBuffer] = await Promise.all([
 		fse.readFile(fullConfig.backgroundPath),
@@ -88,11 +88,31 @@ export async function readIcon(
 	};
 }
 
-function getConfig(config: Optional<Config>): Config {
-	return {
-		backgroundPath: config.backgroundPath || defaultBackgroundPath,
-		foregroundPath: config.foregroundPath || "./icon.svg",
-	};
+async function getConfig(
+	config: Optional<Config>,
+	logger: Logger | undefined,
+): Promise<Config> {
+	const foregroundPath = config.foregroundPath || "./icon.svg";
+
+	if (!(await fse.pathExists(foregroundPath))) {
+		throw new Error(`Icon is required, but not found at ${foregroundPath}`);
+	}
+
+	let backgroundPath: string;
+	if (config.backgroundPath !== undefined) {
+		if (!(await fse.pathExists(config.backgroundPath))) {
+			throw new Error(`Background icon not found at ${config.backgroundPath}`);
+		}
+
+		backgroundPath = config.backgroundPath;
+	} else {
+		logger?.debug(
+			"No background icon specified, falling back to white background",
+		);
+		backgroundPath = defaultBackgroundPath;
+	}
+
+	return { backgroundPath, foregroundPath };
 }
 
 async function loadData(


### PR DESCRIPTION
Move validation concerns from CLI into the lib layer so any caller (CLI, future Expo plugin, etc.) gets them automatically:

- **Foreground icon existence check** → `lib/util/input.getConfig()` — throws if the foreground SVG doesn't exist
- **Background icon existence check** → `lib/util/input.getConfig()` — throws if a caller-provided background path doesn't exist; falls back to bundled white background when no path is given

The CLI now passes raw config directly to `generate()` without pre-validating paths. Background path resolution (detecting the default `./icon-background.svg` on disk) stays in CLI config as a CLI-specific convention.

Also renames `readConfig` → `resolveConfig` to reflect it now performs path resolution beyond just reading/merging config sources.