### PR TITLE
Refactor shared config schemas

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,72 +1,53 @@
 import { type } from "arktype";
 import * as commander from "commander";
 import * as fse from "fs-extra";
+import { Config as LibConfig } from "../lib/config";
 
-// Enable defining commandline options directly in ArkType schema metadata
-declare global {
-	interface ArkEnv {
-		meta(): {
-			cli?: ConstructorParameters<typeof commander.Option>;
-		};
-	}
-}
+const IconConfig = LibConfig.get("icon").required();
 
 /**
  * Schema for configuration properties.
- *
- * CLI option metadata is embedded via ArkType `.configure()` for each property,
- * enabling automatic Commander.js option generation from the same schema.
  */
-const configSchema = type({
-	backgroundPath: type("string")
-		.configure({
-			cli: ["--background-path <path>", "background icon path"],
-		})
-		.default("./icon-background.svg"),
-	foregroundPath: type("string")
-		.configure({
-			cli: ["--foreground-path <path>", "foreground icon path"],
-		})
-		.default("./icon.svg"),
-	platforms: type("('android'|'ios')[]")
-		.configure({
-			cli: [
-				"--platforms <platforms...>",
-				"platforms for which to generate icons",
-			],
-		})
-		.default(() => ["android", "ios"]),
-	force: type("boolean")
-		.configure({
-			cli: ["-f, --force", "overwrite existing newer files"],
-		})
-		.default(false),
-	androidOutputPath: type("string")
-		.configure({
-			cli: ["--android-output-path <path>", "android output path"],
-		})
-		.default("./android/app/src/main/res"),
-	"iosOutputPath?": type("string").configure({
-		cli: ["--ios-output-path <path>", "ios output path"],
-	}),
-	logLevel: type("'silent'|'error'|'warn'|'info'|'debug'")
-		.configure({
-			cli: ["--log-level <level>", "log level"],
-		})
-		.default("info"),
+const CliConfig = LibConfig.omit("appName", "projectRoot", "icon").and({
+	backgroundPath: IconConfig.get("backgroundPath").default(
+		"./icon-background.svg",
+	),
+	foregroundPath: IconConfig.get("foregroundPath").default("./icon.svg"),
+	logLevel: type("'silent'|'error'|'warn'|'info'|'debug'").default("info"),
 });
 
-type ConfigSchema = typeof configSchema.infer;
+type CliConfig = typeof CliConfig.infer;
+
+type CommanderArgs = ConstructorParameters<typeof commander.Option>;
+
+/**
+ * CLI option metadata for each property, enabling Commander.js option
+ * generation for the same values.
+ */
+const configFlags: {
+	[Field in keyof Required<CliConfig>]: CommanderArgs;
+} = {
+	backgroundPath: ["--background-path <path>", "background icon path"],
+	foregroundPath: ["--foreground-path <path>", "foreground icon path"],
+	platforms: [
+		"--platforms <platforms...>",
+		"platforms for which to generate icons",
+	],
+	force: ["-f, --force", "overwrite existing newer files"],
+	androidOutputPath: ["--android-output-path <path>", "android output path"],
+	iosOutputPath: ["--ios-output-path <path>", "ios output path"],
+	logLevel: ["--log-level <level>", "log level"],
+};
 
 const { backgroundPath: defaultBackgroundPath, ...defaultConfig } =
-	configSchema.assert({});
+	CliConfig.assert({});
 
 /**
  * Fully resolved configuration, merged from defaults, app.json, and CLI arguments.
  */
-export type ResolvedConfig = Omit<ConfigSchema, "backgroundPath"> & {
-	backgroundPath?: ConfigSchema["backgroundPath"];
-	appName?: typeof appJsonSchema.infer.name;
+export type ResolvedConfig = Omit<CliConfig, "backgroundPath"> & {
+	backgroundPath?: CliConfig["backgroundPath"];
+	appName?: typeof AppJson.infer.name;
 };
 
 /**
@@ -99,10 +80,10 @@ export async function resolveConfig(
 /**
  * ArkType schema for app.json structure
  */
-const appJsonSchema = type({
+const AppJson = type({
 	"name?": "string",
 	"displayName?": "string",
-	svgAppIcon: configSchema.default(() => ({})),
+	svgAppIcon: CliConfig.default(() => ({})),
 });
 
 async function readAppJsonConfig(): Promise<Partial<ResolvedConfig>> {
@@ -119,13 +100,13 @@ async function readAppJsonConfig(): Promise<Partial<ResolvedConfig>> {
 	}
 
 	// Validate the app.json structure, but omit defaults
-	if (appJsonSchema.allows(rawAppJson)) {
+	if (AppJson.allows(rawAppJson)) {
 		return {
 			...(rawAppJson.name ? { appName: rawAppJson.name } : {}),
 			...rawAppJson.svgAppIcon,
 		};
 	} else {
-		const result = appJsonSchema(rawAppJson);
+		const result = AppJson(rawAppJson);
 		throw new Error(
 			`Invalid app.json: ${result instanceof type.errors ? result.summary : "Unknown validation error"}`,
 		);
@@ -137,11 +118,9 @@ function readCliArgs(args: string[]): Partial<ResolvedConfig> {
 
 	program.name("react-native-svg-app-icon");
 
-	for (const opt of configSchema.props) {
+	for (const opt of CliConfig.props) {
 		const optMeta = opt.value.meta;
-		if (!optMeta?.cli) continue; // Skip properties without CLI flag configuration
-
-		const cliOption = new commander.Option(...optMeta.cli);
+		const cliOption = new commander.Option(...configFlags[opt.key]);
 
 		if (optMeta.default !== undefined) {
 			cliOption.default(optMeta.default);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,23 +4,20 @@ import { resolveConfig } from "./config";
 import { createLogger } from "./logger";
 
 export async function main(args: string[] = []): Promise<void> {
-	const resolvedConfig = await resolveConfig(args);
+	const { logLevel, foregroundPath, backgroundPath, ...libConfig } =
+		await resolveConfig(args);
 
 	// Create logger from config
-	const logger = createLogger(resolvedConfig.logLevel);
+	const logger = createLogger(logLevel);
 
 	logger?.info("Running react-native-svg-app-icon");
 
 	const config: reactNativeSvgAppIcon.Config = {
+		...libConfig,
 		icon: {
-			backgroundPath: resolvedConfig.backgroundPath,
-			foregroundPath: resolvedConfig.foregroundPath,
+			...(backgroundPath !== undefined ? { backgroundPath } : {}),
+			foregroundPath: foregroundPath,
 		},
-		platforms: resolvedConfig.platforms,
-		force: resolvedConfig.force,
-		androidOutputPath: resolvedConfig.androidOutputPath,
-		iosOutputPath: resolvedConfig.iosOutputPath,
-		appName: resolvedConfig.appName,
 		projectRoot: process.cwd(),
 	};
 

--- a/src/lib/android/config.ts
+++ b/src/lib/android/config.ts
@@ -1,13 +1,18 @@
 import * as path from "node:path";
-import type { BaseConfig } from "../config/base";
+import { type } from "arktype";
+import { BaseConfig } from "../config/base";
 
-export interface ResolvedConfig {
-	androidOutputPath: string;
-}
+export const AndroidConfig = type.merge(
+	BaseConfig,
+	type({
+		androidOutputPath: "string = './android/app/src/main/res'",
+	}),
+);
 
-export interface PartialConfig extends BaseConfig, ResolvedConfig {}
+export type AndroidConfig = typeof AndroidConfig.infer;
+export type ResolvedConfig = Pick<AndroidConfig, "androidOutputPath">;
 
-export function getConfig(config: PartialConfig): ResolvedConfig {
+export function getConfig(config: AndroidConfig): ResolvedConfig {
 	return {
 		androidOutputPath: path.resolve(
 			config.projectRoot,

--- a/src/lib/android/index.ts
+++ b/src/lib/android/index.ts
@@ -1,14 +1,14 @@
 import type { Context } from "../util/context";
 import type * as input from "../util/input";
 import { generateAdaptiveIcons } from "./adaptive/adaptive-icons";
-import { getConfig, type PartialConfig, type ResolvedConfig } from "./config";
+import { type AndroidConfig, getConfig, type ResolvedConfig } from "./config";
 import { generateLegacyRoundIcons } from "./legacy/round-icons";
 import { generateLegacySquareIcons } from "./legacy/square-icons";
 
-export type { PartialConfig } from "./config";
+export type { AndroidConfig } from "./config";
 
 export async function* generate(
-	context: Context<PartialConfig>,
+	context: Context<AndroidConfig>,
 	fileInput: input.FileInput,
 ): AsyncIterable<string> {
 	const resolvedContext: Context<ResolvedConfig> = {

--- a/src/lib/android/index.ts
+++ b/src/lib/android/index.ts
@@ -5,7 +5,7 @@ import { type AndroidConfig, getConfig, type ResolvedConfig } from "./config";
 import { generateLegacyRoundIcons } from "./legacy/round-icons";
 import { generateLegacySquareIcons } from "./legacy/square-icons";
 
-export type { AndroidConfig } from "./config";
+export { AndroidConfig } from "./config";
 
 export async function* generate(
 	context: Context<AndroidConfig>,

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,15 +1,21 @@
 import * as crypto from "node:crypto";
+import { type } from "arktype";
 import * as fse from "fs-extra";
-import type { BaseConfig } from "../config/base";
+import { BaseConfig } from "../config/base";
 import type { InputFileBuffers } from "../util/input";
 import type { Logger } from "../util/logger";
 import { getPackageVersion } from "../util/version";
 import { type CacheData, CacheStorage } from "./storage";
 
-export type PartialConfig = BaseConfig & {
-	/** Write output files even if they are up-to-date. */
-	force?: boolean;
-};
+export const CacheConfig = type.merge(
+	BaseConfig,
+	type({
+		/** Write output files even if they are up-to-date. */
+		force: "boolean = false",
+	}),
+);
+
+export type CacheConfig = typeof CacheConfig.infer;
 
 function hashBuffer(buffer: Buffer): string {
 	return crypto.createHash("sha256").update(buffer).digest("hex");
@@ -57,11 +63,11 @@ export class CacheSession {
 		logger,
 	}: {
 		inputFileBuffers: InputFileBuffers;
-		config: PartialConfig;
+		config: CacheConfig;
 		logger: Logger | undefined;
 	}) {
 		this.inputFileBuffers = inputFileBuffers;
-		this.force = config.force ?? false;
+		this.force = config.force;
 		this.logger = logger;
 		this.storage = new CacheStorage(config.projectRoot, logger);
 	}

--- a/src/lib/cache/storage.ts
+++ b/src/lib/cache/storage.ts
@@ -5,7 +5,7 @@ import { type } from "arktype";
 import * as fse from "fs-extra";
 import type { Logger } from "../util/logger";
 
-const cacheDataType = type({
+const CacheData = type({
 	/** Version of react-native-svg-app-icon that wrote this cache entry. */
 	"packageVersion?": "string",
 	inputs: { "[string]": "string" },
@@ -15,7 +15,7 @@ const cacheDataType = type({
 /**
  * Persisted cache state for a single generation run.
  */
-export type CacheData = typeof cacheDataType.infer;
+export type CacheData = typeof CacheData.infer;
 
 /**
  * Handles reading and writing of persisted cache state for a project.
@@ -57,7 +57,7 @@ export class CacheStorage {
 	async read(): Promise<CacheData> {
 		try {
 			const raw: unknown = await fse.readJson(this.cachePath);
-			return cacheDataType.assert(raw);
+			return CacheData.assert(raw);
 		} catch (error) {
 			this.logger?.debug(
 				`Could not read cache at ${this.cachePath}: ${error instanceof Error ? error.message : error}`,

--- a/src/lib/config/base.ts
+++ b/src/lib/config/base.ts
@@ -1,8 +1,20 @@
+import * as path from "node:path";
+import { type } from "arktype";
+
+const AbsolutePath = type("string").narrow((value, ctx) => {
+	if (!path.isAbsolute(value)) {
+		return ctx.mustBe("an absolute path");
+	}
+	return true;
+});
+
 /**
  * Base configuration shared by all sub-module configs.
  * Contains fields that are always required and apply across all platforms.
  */
-export interface BaseConfig {
+export const BaseConfig = type({
 	/** Absolute path to the project root directory. All relative paths resolve against it. */
-	projectRoot: string;
-}
+	projectRoot: AbsolutePath,
+});
+
+export type BaseConfig = typeof BaseConfig.infer;

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,18 +1,24 @@
-import type * as android from "../android";
-import type * as cache from "../cache";
-import type * as ios from "../ios";
-import type * as input from "../util/input";
-import type { BaseConfig } from "./base";
+import { type } from "arktype";
+import { AndroidConfig } from "../android/config";
+import { CacheConfig } from "../cache";
+import { IosConfig } from "../ios/config";
+import { InputConfig } from "../util/input";
 
 /**
  * Supported platforms for generating icons.
  */
-export type Platform = "android" | "ios";
+export const Platform = type("'android'|'ios'");
 
-export type Config = BaseConfig &
-	android.PartialConfig &
-	ios.PartialConfig &
-	input.PartialConfig &
-	cache.PartialConfig & {
-		platforms: Platform[];
-	};
+export const Config = type.merge(
+	InputConfig,
+	AndroidConfig,
+	IosConfig,
+	CacheConfig,
+	type({
+		platforms: Platform.array().default(() => ["android", "ios"]),
+	}),
+);
+
+export type Platform = typeof Platform.infer;
+export type Config = typeof Config.inferIn;
+export type ResolvedConfig = typeof Config.infer;

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,7 +1,7 @@
 import { type } from "arktype";
-import { AndroidConfig } from "../android/config";
+import { AndroidConfig } from "../android";
 import { CacheConfig } from "../cache";
-import { IosConfig } from "../ios/config";
+import { IosConfig } from "../ios";
 import { InputConfig } from "../util/input";
 
 /**

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -26,7 +26,7 @@ describe("lib/index", () => {
 		);
 
 		await expect(generatedFiles[Symbol.asyncIterator]().next()).rejects.toThrow(
-			"config.projectRoot must be an absolute path",
+			"projectRoot must be an absolute path",
 		);
 	});
 });

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,13 +1,13 @@
-import * as path from "node:path";
 import * as android from "./android";
 import { CacheSession } from "./cache";
-import type { Config, Platform } from "./config";
+import { Config, type Platform, type ResolvedConfig } from "./config";
 import * as ios from "./ios";
 import type { Context } from "./util/context";
 import * as input from "./util/input";
 import type { Logger } from "./util/logger";
 
-export type { Config, Platform };
+export { Config } from "./config";
+export type { Platform };
 
 /**
  * Generate platform-specific app icons from SVG source files.
@@ -20,26 +20,28 @@ export async function* generate(
 	config: Config,
 	logger: Logger | undefined,
 ): AsyncIterable<string> {
-	if (!path.isAbsolute(config.projectRoot)) {
-		throw new Error("config.projectRoot must be an absolute path");
-	}
+	const resolvedConfig = Config.assert(config);
 
-	const iconInput = await input.readIcon(config, logger);
+	const iconInput = await input.readIcon(resolvedConfig, logger);
 
 	const cache = new CacheSession({
 		inputFileBuffers: iconInput.fileBuffers,
-		config,
+		config: resolvedConfig,
 		logger,
 	});
 
-	const context: Context<Config> = { config, logger, cache };
+	const context: Context<ResolvedConfig> = {
+		config: resolvedConfig,
+		logger,
+		cache,
+	};
 
 	try {
-		if (config.platforms.includes("android")) {
+		if (resolvedConfig.platforms.includes("android")) {
 			logger?.info("Generating Android icons");
 			yield* android.generate(context, iconInput);
 		}
-		if (config.platforms.includes("ios")) {
+		if (resolvedConfig.platforms.includes("ios")) {
 			logger?.info("Generating iOS icons");
 			yield* ios.generate(context, iconInput);
 		}

--- a/src/lib/ios/config.ts
+++ b/src/lib/ios/config.ts
@@ -22,12 +22,11 @@ export async function getConfig(
 	if (config.iosOutputPath) {
 		logger?.debug(`Using configured iOS output path: ${config.iosOutputPath}`);
 	}
-	const iosOutputPath = config.iosOutputPath
-		? path.resolve(config.projectRoot, config.iosOutputPath)
-		: await getIconsetDir(config, logger);
+
 	return {
-		...config,
-		iosOutputPath,
+		iosOutputPath: config.iosOutputPath
+			? path.resolve(config.projectRoot, config.iosOutputPath)
+			: await getIconsetDir(config, logger),
 	};
 }
 

--- a/src/lib/ios/config.ts
+++ b/src/lib/ios/config.ts
@@ -1,19 +1,22 @@
 import * as path from "node:path";
+import { type } from "arktype";
 import * as fse from "fs-extra";
-import type { BaseConfig } from "../config/base";
+import { BaseConfig } from "../config/base";
 import type { Logger } from "../util/logger";
-import type { Optional } from "../util/optional";
 
-interface PlatformConfig {
-	iosOutputPath: string;
-	appName?: string | undefined;
-}
+export const IosConfig = type.merge(
+	BaseConfig,
+	type({
+		"iosOutputPath?": "string",
+		"appName?": "string",
+	}),
+);
 
-export type PartialConfig = Optional<PlatformConfig> & BaseConfig;
-export type ResolvedConfig = PlatformConfig & BaseConfig;
+export type IosConfig = typeof IosConfig.infer;
+export type ResolvedConfig = Required<Pick<IosConfig, "iosOutputPath">>;
 
 export async function getConfig(
-	config: PartialConfig,
+	config: IosConfig,
 	logger: Logger | undefined,
 ): Promise<ResolvedConfig> {
 	if (config.iosOutputPath) {
@@ -29,7 +32,7 @@ export async function getConfig(
 }
 
 async function getIconsetDir(
-	{ appName, projectRoot }: PartialConfig,
+	{ appName, projectRoot }: IosConfig,
 	logger: Logger | undefined,
 ): Promise<string> {
 	// Prefer the directory matching the app name from app.json, to avoid

--- a/src/lib/ios/index.test.ts
+++ b/src/lib/ios/index.test.ts
@@ -5,7 +5,7 @@ import { cleanupTestOutputs } from "../../../test/utils/cleanup";
 import { makeContext } from "../../../test/utils/context";
 import { verifyGeneratedFiles } from "../../../test/utils/file-comparison";
 import * as input from "../util/input";
-import { generate, type PartialConfig } from "./index";
+import { generate, type IosConfig } from "./index";
 
 describe("ios/index", () => {
 	const assetsPath = path.join(__dirname, "index.test.assets");
@@ -46,7 +46,7 @@ describe("ios/index", () => {
 		it("generates iOS icons and manifest matching reference files", async () => {
 			const baseDir = path.join(assetsPath, "icons");
 			const outputPath = path.join(baseDir, "output");
-			const context = makeContext<PartialConfig>({
+			const context = makeContext<IosConfig>({
 				iosOutputPath: outputPath,
 				projectRoot: baseDir,
 			});

--- a/src/lib/ios/index.ts
+++ b/src/lib/ios/index.ts
@@ -26,7 +26,7 @@ const iosIcons = [
 	{ idiom: "ios-marketing", scale: 1, size: 1024 },
 ];
 
-export type { IosConfig };
+export { IosConfig } from "./config";
 
 export async function* generate(
 	context: Context<IosConfig>,

--- a/src/lib/ios/index.ts
+++ b/src/lib/ios/index.ts
@@ -3,7 +3,7 @@ import type { Context } from "../util/context";
 import * as input from "../util/input";
 import * as output from "../util/output";
 import { prepareForInlining } from "../util/svg";
-import { getConfig, type PartialConfig, type ResolvedConfig } from "./config";
+import { getConfig, type IosConfig, type ResolvedConfig } from "./config";
 
 const iosIcons = [
 	{ idiom: "iphone", scale: 2, size: 20 },
@@ -26,10 +26,10 @@ const iosIcons = [
 	{ idiom: "ios-marketing", scale: 1, size: 1024 },
 ];
 
-export type { PartialConfig };
+export type { IosConfig };
 
 export async function* generate(
-	context: Context<PartialConfig>,
+	context: Context<IosConfig>,
 	fileInput: input.FileInput,
 ): AsyncIterable<string> {
 	const resolvedContext: Context<ResolvedConfig> = {

--- a/src/lib/util/AGENTS.md
+++ b/src/lib/util/AGENTS.md
@@ -11,7 +11,6 @@ Shared infrastructure used across all platform generators.
 - [memoize.ts](memoize.ts) - Caches result of zero-argument functions. Used for lazy-loaded expensive operations (input data).
 - [svg.ts](svg.ts) - SVG preprocessing via SVGO: strips XML declarations, prefixes IDs to prevent collisions when inlining multiple SVGs.
 - [version.ts](version.ts) - Reads package version from `package.json` for cache invalidation.
-- [optional.ts](optional.ts) - `Optional<T>` type utility: all properties optional and explicitly `undefined`-able.
 
 ## Key Patterns
 

--- a/src/lib/util/input.ts
+++ b/src/lib/util/input.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
+import { type } from "arktype";
 import * as fse from "fs-extra";
 
 // sharp library is slow to load, only import types here, and import when needed
 import type * as SharpType from "sharp";
-import type { BaseConfig } from "../config/base";
+import { BaseConfig } from "../config/base";
 import type { Logger } from "./logger";
 import { memoize } from "./memoize";
-import type { Optional } from "./optional";
 
 const defaultBackgroundPath = path.join(
 	__dirname,
@@ -24,12 +24,19 @@ export const inputContentSize = 72;
 /** Margin around the input SVG content within the full image. */
 export const inputImageMargin = (inputImageSize - inputContentSize) / 2;
 
-interface ResolvedConfig {
-	backgroundPath: string;
-	foregroundPath: string;
-}
+export const InputConfig = type.merge(
+	BaseConfig,
+	type({
+		icon: {
+			"backgroundPath?": "string",
+			foregroundPath: "string",
+		},
+	}),
+);
 
-export type PartialConfig = BaseConfig & { icon: Optional<ResolvedConfig> };
+export type InputConfig = typeof InputConfig.infer;
+
+type ResolvedConfig = Required<InputConfig["icon"]>;
 
 export type FileInput = Input<InputData>;
 type InputData = {
@@ -70,7 +77,7 @@ interface BackgroundImageData extends ImageData {
 }
 
 export async function readIcon(
-	config: PartialConfig,
+	config: InputConfig,
 	logger: Logger | undefined,
 ): Promise<FileInput> {
 	const fullConfig = getConfig(config, logger);
@@ -102,16 +109,16 @@ export async function readIcon(
 }
 
 function getConfig(
-	config: PartialConfig,
+	config: InputConfig,
 	logger: Logger | undefined,
 ): ResolvedConfig {
 	const foregroundPath = path.resolve(
 		config.projectRoot,
-		config.icon?.foregroundPath ?? "icon.svg",
+		config.icon.foregroundPath,
 	);
 
 	let backgroundPath: string;
-	if (config.icon?.backgroundPath !== undefined) {
+	if (config.icon.backgroundPath !== undefined) {
 		backgroundPath = path.resolve(
 			config.projectRoot,
 			config.icon.backgroundPath,

--- a/src/lib/util/optional.ts
+++ b/src/lib/util/optional.ts
@@ -1,6 +1,0 @@
-/**
- * Like Partial<T>, but also allows properties to be explicitly undefined.
- */
-export type Optional<T> = {
-	[P in keyof T]?: T[P] | undefined;
-};

--- a/src/lib/util/version.ts
+++ b/src/lib/util/version.ts
@@ -4,7 +4,7 @@ import * as fse from "fs-extra";
 
 const packageJsonPath = path.join(__dirname, "..", "..", "..", "package.json");
 
-const packageJsonSchema = type({ version: "string" });
+const PackageJson = type({ version: "string" });
 
 /**
  * Reads the version field from the package's `package.json` file.
@@ -14,6 +14,6 @@ const packageJsonSchema = type({ version: "string" });
  */
 export async function getPackageVersion(): Promise<string> {
 	const raw = await fse.readJson(packageJsonPath);
-	const pkg = packageJsonSchema.assert(raw);
+	const pkg = PackageJson.assert(raw);
 	return pkg.version;
 }


### PR DESCRIPTION
## Summary
- derive more CLI and app.json config typing from the shared lib config schemas
- simplify config handling across the lib and remove unused optional utility code
- keep undefined-compatibility changes out of this PR and preserve current optional field semantics

## Testing
- npm test