### PR TITLE
Flatten lib config shape

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -3,16 +3,19 @@ import * as commander from "commander";
 import * as fse from "fs-extra";
 import { Config as LibConfig } from "../lib/config";
 
-const IconConfig = LibConfig.get("icon").required();
-
 /**
  * Schema for configuration properties.
  */
-const CliConfig = LibConfig.omit("appName", "projectRoot", "icon").and({
-	backgroundPath: IconConfig.get("backgroundPath").default(
-		"./icon-background.svg",
-	),
-	foregroundPath: IconConfig.get("foregroundPath").default("./icon.svg"),
+const CliConfig = LibConfig.omit(
+	"appName",
+	"projectRoot",
+	"backgroundPath",
+	"foregroundPath",
+).and({
+	backgroundPath: LibConfig.required()
+		.get("backgroundPath")
+		.default("./icon-background.svg"),
+	foregroundPath: LibConfig.get("foregroundPath").default("./icon.svg"),
 	logLevel: type("'silent'|'error'|'warn'|'info'|'debug'").default("info"),
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,8 +4,7 @@ import { resolveConfig } from "./config";
 import { createLogger } from "./logger";
 
 export async function main(args: string[] = []): Promise<void> {
-	const { logLevel, foregroundPath, backgroundPath, ...libConfig } =
-		await resolveConfig(args);
+	const { logLevel, ...libConfig } = await resolveConfig(args);
 
 	// Create logger from config
 	const logger = createLogger(logLevel);
@@ -14,10 +13,6 @@ export async function main(args: string[] = []): Promise<void> {
 
 	const config: reactNativeSvgAppIcon.Config = {
 		...libConfig,
-		icon: {
-			...(backgroundPath !== undefined ? { backgroundPath } : {}),
-			foregroundPath: foregroundPath,
-		},
 		projectRoot: process.cwd(),
 	};
 

--- a/src/lib/android/adaptive/adaptive-icons.test.ts
+++ b/src/lib/android/adaptive/adaptive-icons.test.ts
@@ -34,13 +34,11 @@ describe("android/adaptive-icons", () => {
 			const fileInput = await input.readIcon(
 				{
 					projectRoot: baseDir,
-					icon: {
-						backgroundPath: path.join(
-							testAssetsPath,
-							"react-icon-background.svg",
-						),
-						foregroundPath: path.join(testAssetsPath, "react-icon.svg"),
-					},
+					backgroundPath: path.join(
+						testAssetsPath,
+						"react-icon-background.svg",
+					),
+					foregroundPath: path.join(testAssetsPath, "react-icon.svg"),
 				},
 				undefined,
 			);
@@ -67,9 +65,7 @@ describe("android/adaptive-icons", () => {
 			const unsupportedFileInput = await input.readIcon(
 				{
 					projectRoot: baseDir,
-					icon: {
-						foregroundPath: path.join(testAssetsPath, "text-icon.svg"),
-					},
+					foregroundPath: path.join(testAssetsPath, "text-icon.svg"),
 				},
 				undefined,
 			);

--- a/src/lib/android/adaptive/vector-drawable.test.ts
+++ b/src/lib/android/adaptive/vector-drawable.test.ts
@@ -31,7 +31,7 @@ describe("android/vector-drawable", () => {
 			const fileInput = await input.readIcon(
 				{
 					projectRoot: assetsPath,
-					icon: { foregroundPath: path.join(testAssetsPath, "react-icon.svg") },
+					foregroundPath: path.join(testAssetsPath, "react-icon.svg"),
 				},
 				undefined,
 			);
@@ -68,7 +68,7 @@ describe("android/vector-drawable", () => {
 			const unsupportedFileInput = await input.readIcon(
 				{
 					projectRoot: assetsPath,
-					icon: { foregroundPath: path.join(testAssetsPath, "text-icon.svg") },
+					foregroundPath: path.join(testAssetsPath, "text-icon.svg"),
 				},
 				undefined,
 			);

--- a/src/lib/android/legacy/round-icons.test.ts
+++ b/src/lib/android/legacy/round-icons.test.ts
@@ -30,16 +30,8 @@ describe("android/legacy/round-icons", () => {
 		fileInput = await input.readIcon(
 			{
 				projectRoot: baseDir,
-				icon: {
-					backgroundPath: path.join(
-						testAssetsPath,
-						"square-icon-background.svg",
-					),
-					foregroundPath: path.join(
-						testAssetsPath,
-						"square-icon-foreground.svg",
-					),
-				},
+				backgroundPath: path.join(testAssetsPath, "square-icon-background.svg"),
+				foregroundPath: path.join(testAssetsPath, "square-icon-foreground.svg"),
 			},
 			undefined,
 		);

--- a/src/lib/android/legacy/square-icons.test.ts
+++ b/src/lib/android/legacy/square-icons.test.ts
@@ -30,16 +30,8 @@ describe("android/legacy/square-icons", () => {
 		fileInput = await input.readIcon(
 			{
 				projectRoot: baseDir,
-				icon: {
-					backgroundPath: path.join(
-						testAssetsPath,
-						"square-icon-background.svg",
-					),
-					foregroundPath: path.join(
-						testAssetsPath,
-						"square-icon-foreground.svg",
-					),
-				},
+				backgroundPath: path.join(testAssetsPath, "square-icon-background.svg"),
+				foregroundPath: path.join(testAssetsPath, "square-icon-foreground.svg"),
 			},
 			undefined,
 		);

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -11,16 +11,14 @@ describe("lib/index", () => {
 				platforms: [],
 				force: false,
 				androidOutputPath: "./android/app/src/main/res",
-				icon: {
-					foregroundPath: path.join(
-						__dirname,
-						"..",
-						"..",
-						"test",
-						"assets",
-						"react-icon.svg",
-					),
-				},
+				foregroundPath: path.join(
+					__dirname,
+					"..",
+					"..",
+					"test",
+					"assets",
+					"react-icon.svg",
+				),
 			},
 			undefined,
 		);

--- a/src/lib/ios/index.test.ts
+++ b/src/lib/ios/index.test.ts
@@ -30,13 +30,8 @@ describe("ios/index", () => {
 		fileInput = await input.readIcon(
 			{
 				projectRoot: assetsPath,
-				icon: {
-					backgroundPath: path.join(
-						testAssetsPath,
-						"react-icon-background.svg",
-					),
-					foregroundPath: path.join(testAssetsPath, "react-icon.svg"),
-				},
+				backgroundPath: path.join(testAssetsPath, "react-icon-background.svg"),
+				foregroundPath: path.join(testAssetsPath, "react-icon.svg"),
 			},
 			undefined,
 		);

--- a/src/lib/util/input.ts
+++ b/src/lib/util/input.ts
@@ -27,16 +27,16 @@ export const inputImageMargin = (inputImageSize - inputContentSize) / 2;
 export const InputConfig = type.merge(
 	BaseConfig,
 	type({
-		icon: {
-			"backgroundPath?": "string",
-			foregroundPath: "string",
-		},
+		"backgroundPath?": "string",
+		foregroundPath: "string",
 	}),
 );
 
 export type InputConfig = typeof InputConfig.infer;
 
-type ResolvedConfig = Required<InputConfig["icon"]>;
+type ResolvedConfig = Required<
+	Pick<InputConfig, "backgroundPath" | "foregroundPath">
+>;
 
 export type FileInput = Input<InputData>;
 type InputData = {
@@ -114,15 +114,12 @@ function getConfig(
 ): ResolvedConfig {
 	const foregroundPath = path.resolve(
 		config.projectRoot,
-		config.icon.foregroundPath,
+		config.foregroundPath,
 	);
 
 	let backgroundPath: string;
-	if (config.icon.backgroundPath !== undefined) {
-		backgroundPath = path.resolve(
-			config.projectRoot,
-			config.icon.backgroundPath,
-		);
+	if (config.backgroundPath !== undefined) {
+		backgroundPath = path.resolve(config.projectRoot, config.backgroundPath);
 	} else {
 		logger?.debug(
 			"No background icon specified, falling back to white background",


### PR DESCRIPTION
## What
- flatten the library input config so foreground and background paths are top-level fields
- simplify CLI config forwarding to pass the lib config through directly
- update tests to use the flattened config shape
- keep the ArkType CLI config type-safe after the schema cleanup

## Verification
- npm test
